### PR TITLE
Remove outdated DataDashboard section (#197)

### DIFF
--- a/docs/developer/continuous_deployment.md
+++ b/docs/developer/continuous_deployment.md
@@ -33,7 +33,7 @@ Take note of the Application (client) ID.
 
 Below, we create two credentials: one for federated authentication for GitHub Actions, and one with client secret for Terraform (required as Terraform does not yet support Azure CLI login with a service principal).
 
-Follow the instructions to [Configure a federated identity credential]([Configure a federated identity credential](https://docs.microsoft.com/azure/active-directory/develop/workload-identity-federation-create-trust-github?tabs=azure-portal#configure-a-federated-identity-credential)) for the `main` branch.
+Follow the instructions to [Configure a federated identity credential](https://docs.microsoft.com/azure/active-directory/develop/workload-identity-federation-create-trust-github?tabs=azure-portal#configure-a-federated-identity-credential) for the `main` branch.
 
 - For **Entity Type**, select **Branch**.
 - For **GitHub branch name**, enter `main`.
@@ -97,9 +97,3 @@ This prefix should help have unique resource names across fork repositories when
 ### Deploying CD resources
 
 Manually run the `Initialize CD` GitHub Actions workflow.
-
-### Deploying Data Dashboard
-
-Fork the **EDC Data Dashboard** web app and run its deploy action.
-
-Adapt the default value of the Data Dashboard image tag (`data_dashboard_image_tag` variable) in the [Terraform variables](deployment/terraform/variables.tf) to reflect the tag of the **EDC Data Dashboard** web app deployment.


### PR DESCRIPTION
[CD documentation](https://github.com/eclipse-dataspaceconnector/MinimumViableDataspace/blob/main/docs/developer/continuous_deployment.md) contains outdated information about deploying the `DataDashboard`.

The `DataDahboard` is now being built and deployed as part of the `Deploy` pipeline.

Thi PR removes last section in the DC documentation about the `DataDahboard` and fixes a link formatting issue.

Related to downstream issue https://github.com/agera-edc/MinimumViableDataspace/issues/195.