### PR TITLE
Bug/205 fix CD identity / Key Vault RBAC propagation issues

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -207,7 +207,7 @@ jobs:
           TF_VAR_public_key_jwk_file_authority: "authoritykey.public.jwk"
           TF_VAR_public_key_jwk_file_gaiax: "gaiaxkey.public.jwk"
 
-      - name: 'Az CLI login'
+      - name: 'Az CLI re-login (refresh role assignments)'
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.ARM_CLIENT_ID }}
@@ -354,7 +354,7 @@ jobs:
           TF_VAR_application_sp_client_secret: ${{ secrets.APP_CLIENT_SECRET }}
           TF_VAR_app_insights_connection_string: ${{ needs.Deploy-Dataspace.outputs.app_insights_connection_string }}
 
-      - name: 'Az CLI login'
+      - name: 'Az CLI re-login (refresh role assignments)'
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.ARM_CLIENT_ID }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -183,6 +183,10 @@ jobs:
           ' >> backend.conf
           terraform init -backend-config=backend.conf
           terraform apply -auto-approve
+          connector_name=$(terraform output -raw connector_name)
+          echo "::set-output name=connector_name::${connector_name}"
+          key_vault=$(terraform output -raw key_vault)
+          echo "::set-output name=key_vault::${key_vault}"
           app_insights_connection_string=$(terraform output -raw app_insights_connection_string)
           echo "::set-output name=app_insights_connection_string::${app_insights_connection_string}"
           registration_service_url=$(terraform output -raw registration_service_url)
@@ -200,9 +204,21 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
           # Terraform variables not included in terraform.tfvars.
-          TF_VAR_key_file_authority: "authoritykey.pem"
           TF_VAR_public_key_jwk_file_authority: "authoritykey.public.jwk"
           TF_VAR_public_key_jwk_file_gaiax: "gaiaxkey.public.jwk"
+
+      - name: 'Az CLI login'
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.ARM_CLIENT_ID }}
+          tenant-id: ${{ secrets.ARM_TENANT_ID }}
+          subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+
+      - name: 'Upload private key as vault secret'
+        run: az keyvault secret set --name "$name" --vault-name "$vault" --file authoritykey.pem -o none
+        env:
+          name: ${{ steps.runterraform.outputs.connector_name }}
+          vault: ${{ steps.runterraform.outputs.key_vault }}
 
       - name: 'Verify GAIA-X Authority DID endpoint is available'
         run: curl https://${{ steps.runterraform.outputs.gaiax_did_host }}/.well-known/did.json | jq '.id'
@@ -301,14 +317,22 @@ jobs:
           DID_HOST=$(terraform output -raw did_host)
           EDC_HOST=$(terraform output -raw edc_host)
           ASSETS_STORAGE_ACCOUNT=$(terraform output -raw assets_storage_account)
+          ASSETS_STORAGE_ACCOUNT_KEY=$(terraform output -raw assets_storage_account_key)
+          INBOX_STORAGE_ACCOUNT=$(terraform output -raw inbox_storage_account)
+          INBOX_STORAGE_ACCOUNT_KEY=$(terraform output -raw inbox_storage_account_key)
           KEY_VAULT=$(terraform output -raw key_vault)
           WEBAPP_URL=$(terraform output -raw webapp_url)
           API_KEY=$(terraform output -raw api_key)
           echo "::notice title=MVD WebApp for ${{ matrix.participant }}::$WEBAPP_URL"
           echo "ASSETS_STORAGE_ACCOUNT=$ASSETS_STORAGE_ACCOUNT" >> $GITHUB_ENV
+          echo "ASSETS_STORAGE_ACCOUNT_KEY=$ASSETS_STORAGE_ACCOUNT_KEY" >> $GITHUB_ENV
+          echo "INBOX_STORAGE_ACCOUNT=$INBOX_STORAGE_ACCOUNT" >> $GITHUB_ENV
+          echo "INBOX_STORAGE_ACCOUNT_KEY=$INBOX_STORAGE_ACCOUNT_KEY" >> $GITHUB_ENV
           echo "DID_HOST=$DID_HOST" >> $GITHUB_ENV
           echo "EDC_HOST=$EDC_HOST" >> $GITHUB_ENV
           echo "API_KEY=$API_KEY" >> $GITHUB_ENV
+          echo "CONNECTOR_NAME=$CONNECTOR_NAME" >> $GITHUB_ENV
+          echo "KEY_VAULT=$KEY_VAULT" >> $GITHUB_ENV
           echo "::set-output name=${{ matrix.participant }}_edc_host::${EDC_HOST}"
           echo "::set-output name=${{ matrix.participant }}_key_vault::${KEY_VAULT}"
           echo "::set-output name=${{ matrix.participant }}_api_key::${API_KEY}"
@@ -326,10 +350,25 @@ jobs:
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
           # Terraform variables not included in terraform.tfvars.
-          TF_VAR_key_file: "key.pem"
           TF_VAR_public_key_jwk_file: "key.public.jwk"
           TF_VAR_application_sp_client_secret: ${{ secrets.APP_CLIENT_SECRET }}
           TF_VAR_app_insights_connection_string: ${{ needs.Deploy-Dataspace.outputs.app_insights_connection_string }}
+
+      - name: 'Az CLI login'
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.ARM_CLIENT_ID }}
+          tenant-id: ${{ secrets.ARM_TENANT_ID }}
+          subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+
+      - name: 'Upload private key as vault secret'
+        run: az keyvault secret set --name "$CONNECTOR_NAME" --vault-name "$KEY_VAULT" --file key.pem -o none
+
+      - name: 'Upload asset storage account key as vault secret'
+        run: az keyvault secret set --name "$ASSETS_STORAGE_ACCOUNT-key1" --vault-name "$KEY_VAULT" --value "$ASSETS_STORAGE_ACCOUNT_KEY" -o none
+
+      - name: 'Upload inbox storage account key as vault secret'
+        run: az keyvault secret set --name "$INBOX_STORAGE_ACCOUNT-key1" --vault-name "$KEY_VAULT" --value "$INBOX_STORAGE_ACCOUNT_KEY" -o none
 
       - name: 'Verify did endpoint is available'
         run: curl https://$DID_HOST/.well-known/did.json | jq '.id'

--- a/deployment/terraform/dataspace/main.tf
+++ b/deployment/terraform/dataspace/main.tf
@@ -132,17 +132,6 @@ resource "azurerm_storage_account" "dataspace_did" {
   static_website {}
 }
 
-resource "azurerm_key_vault_secret" "dataspace_did_key" {
-  name = local.connector_name
-  # Create did_key secret only if key_file value is provided. Default key_file value is null.
-  count        = var.key_file_authority == null ? 0 : 1
-  value        = file(var.key_file_authority)
-  key_vault_id = azurerm_key_vault.registrationservice.id
-  depends_on = [
-    azurerm_role_assignment.current-user-secretsofficer
-  ]
-}
-
 resource "azurerm_storage_blob" "dataspace_did" {
   name                 = ".well-known/did.json" # `.well-known` path is defined by did:web specification
   storage_account_name = azurerm_storage_account.dataspace_did.name

--- a/deployment/terraform/dataspace/outputs.tf
+++ b/deployment/terraform/dataspace/outputs.tf
@@ -1,3 +1,11 @@
+output "connector_name" {
+  value = local.connector_name
+}
+
+output "key_vault" {
+  value = azurerm_key_vault.registrationservice.name
+}
+
 output "app_insights_connection_string" {
   value     = azurerm_application_insights.dataspace.connection_string
   sensitive = true

--- a/deployment/terraform/dataspace/variables.tf
+++ b/deployment/terraform/dataspace/variables.tf
@@ -35,11 +35,6 @@ variable "application_sp_object_id" {
   description = "object id of application's service principal object"
 }
 
-variable "key_file_authority" {
-  description = "name of a file containing the Registration Service private key in PEM format"
-  default     = null
-}
-
 variable "public_key_jwk_file_authority" {
   description = "name of a file containing the Registration Service public key in JWK format"
   default     = null

--- a/deployment/terraform/participant/main.tf
+++ b/deployment/terraform/participant/main.tf
@@ -230,15 +230,6 @@ resource "azurerm_storage_account" "inbox" {
   account_kind             = "StorageV2"
 }
 
-resource "azurerm_key_vault_secret" "inbox_storage_key" {
-  name         = "${azurerm_storage_account.inbox.name}-key1"
-  value        = azurerm_storage_account.inbox.primary_access_key
-  key_vault_id = azurerm_key_vault.participant.id
-  depends_on = [
-    azurerm_role_assignment.current-user-secretsofficer
-  ]
-}
-
 resource "azurerm_storage_container" "assets_container" {
   name                 = "src-container"
   storage_account_name = azurerm_storage_account.assets.name
@@ -258,26 +249,6 @@ resource "azurerm_storage_blob" "testfile2" {
   storage_container_name = azurerm_storage_container.assets_container.name
   type                   = "Block"
   source                 = "sample-data/text-document.txt"
-}
-
-resource "azurerm_key_vault_secret" "asset_storage_key" {
-  name         = "${azurerm_storage_account.assets.name}-key1"
-  value        = azurerm_storage_account.assets.primary_access_key
-  key_vault_id = azurerm_key_vault.participant.id
-  depends_on = [
-    azurerm_role_assignment.current-user-secretsofficer
-  ]
-}
-
-resource "azurerm_key_vault_secret" "did_key" {
-  name = local.connector_name
-  # Create did_key secret only if key_file value is provided. Default key_file value is null.
-  count        = var.key_file == null ? 0 : 1
-  value        = file(var.key_file)
-  key_vault_id = azurerm_key_vault.participant.id
-  depends_on = [
-    azurerm_role_assignment.current-user-secretsofficer
-  ]
 }
 
 resource "azurerm_storage_blob" "did" {

--- a/deployment/terraform/participant/outputs.tf
+++ b/deployment/terraform/participant/outputs.tf
@@ -7,7 +7,7 @@ output "assets_storage_account" {
 }
 
 output "assets_storage_account_key" {
-  value = azurerm_storage_account.assets.primary_access_key
+  value     = azurerm_storage_account.assets.primary_access_key
   sensitive = true
 }
 
@@ -16,7 +16,7 @@ output "inbox_storage_account" {
 }
 
 output "inbox_storage_account_key" {
-  value = azurerm_storage_account.inbox.primary_access_key
+  value     = azurerm_storage_account.inbox.primary_access_key
   sensitive = true
 }
 

--- a/deployment/terraform/participant/outputs.tf
+++ b/deployment/terraform/participant/outputs.tf
@@ -6,6 +6,20 @@ output "assets_storage_account" {
   value = azurerm_storage_account.assets.name
 }
 
+output "assets_storage_account_key" {
+  value = azurerm_storage_account.assets.primary_access_key
+  sensitive = true
+}
+
+output "inbox_storage_account" {
+  value = azurerm_storage_account.inbox.name
+}
+
+output "inbox_storage_account_key" {
+  value = azurerm_storage_account.inbox.primary_access_key
+  sensitive = true
+}
+
 output "key_vault" {
   value = azurerm_key_vault.participant.name
 }

--- a/deployment/terraform/participant/variables.tf
+++ b/deployment/terraform/participant/variables.tf
@@ -61,11 +61,6 @@ variable "application_sp_client_secret" {
   sensitive   = true
 }
 
-variable "key_file" {
-  description = "name of a file containing the private key in PEM format"
-  default     = null
-}
-
 variable "public_key_jwk_file" {
   description = "name of a file containing the public key in JWK format"
   default     = null

--- a/docs/developer/decision-records/2022-07-19-cd-vault-secrets/README.md
+++ b/docs/developer/decision-records/2022-07-19-cd-vault-secrets/README.md
@@ -1,0 +1,11 @@
+# Deployment of Azure Key Vault secrets
+
+## Decision
+
+Terraform deploys Azure Key Vault instances and configures Role-Based Acess Control to allow the CD pipeline service principal to write secrets.
+
+Secrets are written to Azure Key Vault in CD pipeline actions, and not within Terraform actions, and not within the Terraform deployment. The CD pipeline obtains a fresh Azure AD access token after Terraform deployment, to ensure role assignments are propagated.
+
+## Rationale
+
+Propagation of role assignments [can take up to 30 minutes](https://docs.microsoft.com/en-us/azure/role-based-access-control/troubleshooting#role-assignment-changes-are-not-being-detected). This can be circumvented by issuing a new Azure AD access token, which is not possible within a Terraform deployment.

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferIntegrationTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/local/BlobTransferIntegrationTest.java
@@ -16,7 +16,7 @@
 
 package org.eclipse.dataspaceconnector.system.tests.local;
 
-import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.identity.AzureCliCredentialBuilder;
 import com.azure.security.keyvault.secrets.SecretClientBuilder;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
@@ -64,7 +64,8 @@ public class BlobTransferIntegrationTest {
 
     @NotNull
     private BlobServiceClient getBlobServiceClient(String keyVaultName) {
-        var credential = new DefaultAzureCredentialBuilder().build();
+        // Not using DefaultAzureCredentialBuilder because of agent issue https://github.com/orgs/github-community/discussions/20830
+        var credential = new AzureCliCredentialBuilder().build();
         var vault = new SecretClientBuilder()
                 .vaultUrl(format(KEY_VAULT_ENDPOINT_TEMPLATE, keyVaultName))
                 .credential(credential)


### PR DESCRIPTION
## What this PR changes/adds

- Avoid attempting to use Managed Identity for Azure login for test runs
- Deploy AKV secrets in CD, rather than Terraform.

## Why it does that

Resolve two causes of failing CD runs.
- Ensure correct identity is picked up when running tests. [As reported](https://github.com/orgs/github-community/discussions/20830), a Managed Identity is sometimes unexpectedly attached to GitHub runners.
- Account for role assignment propagation time. See ADR included for details.

## Further notes

## Linked Issue(s)

Closes https://github.com/agera-edc/MinimumViableDataspace/issues/205

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly?
