### PR TITLE
Registration Service JWS authentication

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -16,7 +16,7 @@ runs:
       with:
         repository: eclipse-dataspaceconnector/RegistrationService
         path: RegistrationService
-        ref: 374c14bcca23ddb1dcd7476a27264510e54de7fa
+        ref: daa414856b42c8534e9123279112e33b366039b4
 
     - name: Checkout Identity Hub
       uses: actions/checkout@v2

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -26,20 +26,19 @@ jobs:
         run: ./gradlew :launcher:shadowJar
         working-directory: ${{ runner.temp }}/RegistrationService
 
+      - name: 'Copy Registration Service CLI'
+        run: |
+          mvn dependency:copy -Dartifact=org.eclipse.dataspaceconnector.registrationservice:registration-service-cli:$REGISTRATION_SERVICE_VERSION:jar:all -DoutputDirectory=.
+          mv registration-service-cli-$REGISTRATION_SERVICE_VERSION-all.jar registration-service-cli.jar
+        working-directory: system-tests/resources/cli-tools
+        env:
+           REGISTRATION_SERVICE_VERSION: 0.0.1-SNAPSHOT
+
       - name: 'Run MVD docker-compose'
         run: docker-compose -f system-tests/docker-compose.yml up --build --detach
         timeout-minutes: 10
         env:
           REGISTRATION_SERVICE_LAUNCHER_PATH: ${{ runner.temp }}/RegistrationService/launcher
-
-      - name: 'Register participant'
-        run: |
-          mvn dependency:copy -Dartifact=org.eclipse.dataspaceconnector.registrationservice:registration-service-cli:1.0.0-SNAPSHOT:jar:all -DoutputDirectory=.
-          chmod +x system-tests/resources/register-participants.sh
-          system-tests/resources/register-participants.sh
-        working-directory: .
-        env:
-          REGISTRATION_SERVICE_CLI_JAR_PATH: ./registration-service-cli-1.0.0-SNAPSHOT-all.jar
 
       - name: 'Unit and system tests'
         run: ./gradlew test

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -2,7 +2,6 @@ name: Checks
 
 on:
   pull_request:
-    branches: [ main ]
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -220,21 +220,11 @@ jobs:
           name: ${{ steps.runterraform.outputs.connector_name }}
           vault: ${{ steps.runterraform.outputs.key_vault }}
 
-      # To support --retry-all-errors flag at least curl version 7.71.0 is required.
-      - name: 'Upgrade Curl'
-        run: sudo -E bash deployment/curl-upgrade.sh
-        working-directory: .
-        env:
-          VERSION: 7.84.0
-
       - name: 'Verify GAIA-X Authority DID endpoint is available'
         run: curl https://${{ steps.runterraform.outputs.gaiax_did_host }}/.well-known/did.json | jq '.id'
 
       - name: 'Verify Dataspace DID endpoint is available'
         run: curl https://${{ steps.runterraform.outputs.dataspace_did_host }}/.well-known/did.json | jq '.id'
-
-      - name: 'Verify deployed Registration Service is healthy'
-        run: curl --retry 10 --retry-all-errors --fail ${{ steps.runterraform.outputs.registration_service_url }}/api/check/health
 
   # Deploy dataspace participants in parallel.
   Deploy-Participants:
@@ -295,7 +285,7 @@ jobs:
           dashboard_image = "mvd/data-dashboard:${{ env.RESOURCES_PREFIX }}"
           application_sp_object_id = "${{ secrets.APP_OBJECT_ID }}"
           application_sp_client_id = "${{ secrets.APP_CLIENT_ID }}"
-          registration_service_api_url = "${{ needs.Deploy-Dataspace.outputs.registration_service_url }}/api"
+          registration_service_api_url = "${{ needs.Deploy-Dataspace.outputs.registration_service_url }}/authority"
           EOF
 
       - name: 'Az CLI login'
@@ -398,10 +388,15 @@ jobs:
 
       - name: 'Register participant'
         run: |
-          mvn dependency:copy -Dartifact=org.eclipse.dataspaceconnector.registrationservice:registration-service-cli:1.0.0-SNAPSHOT:jar:all -DoutputDirectory=.
-          java -jar registration-service-cli-1.0.0-SNAPSHOT-all.jar -s=$REGISTRATION_SERVICE_API_URL participants add --request='{ "name": "${{matrix.participant}}", "supportedProtocols": [ "ids-multipart" ], "url": "http://${{ env.EDC_HOST }}:8282" }'
+          mvn dependency:copy -Dartifact=org.eclipse.dataspaceconnector.registrationservice:registration-service-cli:0.0.1-SNAPSHOT:jar:all -DoutputDirectory=.
+          java -jar registration-service-cli-0.0.1-SNAPSHOT-all.jar \
+            -s $REGISTRATION_SERVICE_API_URL \
+            -d did:web:$DID_HOST \
+            -k key.pem \
+            participants add \
+            --ids-url "http://${{ env.EDC_HOST }}:8282"
         env:
-          REGISTRATION_SERVICE_API_URL: ${{ needs.Deploy-Dataspace.outputs.registration_service_url }}/api
+          REGISTRATION_SERVICE_API_URL: ${{ needs.Deploy-Dataspace.outputs.registration_service_url }}/authority
 
   Verify:
     needs:

--- a/deployment/terraform/dataspace/main.tf
+++ b/deployment/terraform/dataspace/main.tf
@@ -37,8 +37,11 @@ locals {
 
   connector_name = "connector-registration"
 
-  registration_service_dns_label = "${var.prefix}-registration-mvd"
-  edc_default_port               = 8181
+  registration_service_dns_label   = "${var.prefix}-registration-mvd"
+  edc_default_port                 = 8181
+  registration_service_port        = 8182
+  registration_service_path_prefix = "/authority"
+  registration_service_url         = "http://${local.registration_service_dns_label}.${var.location}.azurecontainer.io:${local.registration_service_port}"
 
   dataspace_did_url = "did:web:${azurerm_storage_account.dataspace_did.primary_web_host}"
   gaiax_did_url     = "did:web:${azurerm_storage_account.gaiax_did.primary_web_host}"
@@ -77,17 +80,20 @@ resource "azurerm_container_group" "registration-service" {
     memory = var.container_memory
 
     ports {
-      port     = local.edc_default_port
+      port     = local.registration_service_port
       protocol = "TCP"
     }
 
     environment_variables = {
-      EDC_CONNECTOR_NAME = local.connector_name
+      EDC_CONNECTOR_NAME      = local.connector_name
+      JWT_AUDIENCE            = "${local.registration_service_url}${local.registration_service_path_prefix}"
+      WEB_HTTP_AUTHORITY_PORT = local.registration_service_port
+      WEB_HTTP_AUTHORITY_PATH = local.registration_service_path_prefix
     }
 
     liveness_probe {
       http_get {
-        port = 8181
+        port = local.edc_default_port
         path = "/api/check/health"
       }
       initial_delay_seconds = 10

--- a/deployment/terraform/dataspace/outputs.tf
+++ b/deployment/terraform/dataspace/outputs.tf
@@ -12,7 +12,7 @@ output "app_insights_connection_string" {
 }
 
 output "registration_service_url" {
-  value = "http://${azurerm_container_group.registration-service.fqdn}:${local.edc_default_port}"
+  value = local.registration_service_url
 }
 
 output "dataspace_did_host" {

--- a/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/RegistrationServiceNodeDirectoryExtension.java
+++ b/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/RegistrationServiceNodeDirectoryExtension.java
@@ -15,10 +15,13 @@
 package org.eclipse.dataspaceconnector.mvd;
 
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheNodeDirectory;
-import org.eclipse.dataspaceconnector.common.configuration.ConfigurationFunctions;
 import org.eclipse.dataspaceconnector.registration.client.ApiClientFactory;
 import org.eclipse.dataspaceconnector.registration.client.api.RegistryApi;
-import org.eclipse.dataspaceconnector.spi.system.Provides;
+import org.eclipse.dataspaceconnector.spi.EdcSetting;
+import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.system.Inject;
+import org.eclipse.dataspaceconnector.spi.system.Provider;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
@@ -26,18 +29,34 @@ import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 /**
  * Extension to set up federated cache directory using Registration Service API as backend.
  */
-@Provides(FederatedCacheNodeDirectory.class)
 public class RegistrationServiceNodeDirectoryExtension implements ServiceExtension {
 
-    static final String API_URL = "http://localhost:8181/api";
+    @EdcSetting
+    private static final String REGISTRATION_SERVICE_API_URL = "registration.service.api.url";
+    private static final String REGISTRATION_SERVICE_API_URL_DEFAULT = "http://localhost:8182/authority";
+
+    @Inject
+    private Monitor monitor;
+
+    @Inject
+    private TypeManager typeManager;
+
+    @Inject
+    private IdentityService identityService;
+
+    private String registrationServiceApiUrl;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var monitor = context.getMonitor();
-        TypeManager typeManager = context.getTypeManager();
-        var registrationServiceApiUrl = ConfigurationFunctions.propOrEnv("registration.service.api.url", API_URL);
-        var service = new RegistrationServiceNodeDirectory(new RegistryApi(ApiClientFactory.createApiClient(registrationServiceApiUrl)));
-        context.registerService(FederatedCacheNodeDirectory.class, service);
+        registrationServiceApiUrl = context.getSetting(
+                REGISTRATION_SERVICE_API_URL, REGISTRATION_SERVICE_API_URL_DEFAULT);
+    }
+
+    @Provider
+    public FederatedCacheNodeDirectory federatedCacheNodeDirectory() {
+        var apiClient = ApiClientFactory.createApiClient(registrationServiceApiUrl, identityService::obtainClientCredentials);
+        var registryApiClient = new RegistryApi(apiClient);
+        return new RegistrationServiceNodeDirectory(registryApiClient);
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 edcGroup=org.eclipse.dataspaceconnector
 edcVersion=0.0.1-SNAPSHOT
 registrationServiceGroup=org.eclipse.dataspaceconnector.registrationservice
-registrationServiceVersion=1.0.0-SNAPSHOT
+registrationServiceVersion=0.0.1-SNAPSHOT
 identityHubGroup=org.eclipse.dataspaceconnector.identityhub
 identityHubVersion=0.0.1-SNAPSHOT
 gatlingVersion=3.7.5

--- a/system-tests/README.md
+++ b/system-tests/README.md
@@ -5,17 +5,17 @@ The system tests copies a file from a provider to a consumer blob storage accoun
 ## Publish/Build Tasks
 
 > ! Important Note !
-> 
-> MVD depends on Eclipse DataSpaceConnector(EDC), Identity Hub and Registration Service. These dependencies 
-> are __not__ published to any central artifact repository yet, so in local development we have to use locally 
+>
+> MVD depends on Eclipse DataSpaceConnector(EDC), Identity Hub and Registration Service. These dependencies
+> are __not__ published to any central artifact repository yet, so in local development we have to use locally
 > published dependencies.
 >
 >In order to use the correct version of each repo required by the `MVD`, you need to look in [action.yml](./.github/actions/../../../.github/actions/gradle-setup/action.yml) for the hashes of the versions of the `EDC`, `Identity Hub` and the `Registration Service` that are being used by the `MVD`.
 >
 > For Example for the dependency repositories:
 > - `Registration Service`
-> - `Identity Hub` 
-> - `EDC` 
+> - `Identity Hub`
+> - `EDC`
 >
 >  the hash (which is subject to change from the values presented here as an example) can be found in the _Checkout_ steps  (in the `ref` property) of [action.yml](./.github/actions/gradle-setup/action.yml):
 
@@ -44,7 +44,7 @@ The system tests copies a file from a provider to a consumer blob storage accoun
 ```
 
 > After you have cloned the `EDC`, `Identity Hub` and `Registration Service` repos locally you should run the command to
-> `checkout` to the specific hash.  
+> `checkout` to the specific hash.
 >
 > For Example:
 
@@ -59,9 +59,9 @@ git checkout bc13cf0cb8589b792eef733c7cf7b3422476add5
 git checkout 374c14bcca23ddb1dcd7476a27264510e54de7fa
 ```
 
-> Now you can follow the rest of the process below.  
+> Now you can follow the rest of the process below.
 > Once the publications are available in _Maven Central_ this process will not be necessary
-> 
+>
 <br />
 
 ### EDC
@@ -113,7 +113,7 @@ Now that the publishing to the local repositories has been completed, `MVD` can 
 
 ## Local Test Execution
 
-- `MVD` system tests can be executed locally against a local `MVD` instance. 
+- `MVD` system tests can be executed locally against a local `MVD` instance.
 - `MVD` runs three `EDC Connectors` and one `Registration Service`.
 
 _Note: Ensure that you are able to build `MVD` locally as described in the previous [section](#mvd)._
@@ -132,7 +132,9 @@ From the `Registration Service` root folder, execute the following command:
 ./gradlew :launcher:shadowJar
 ```
 
-From the `MVD` root folder execute the following commands to set the `Registration Launcher` path environment variable and start `MVD` using the `docker-compose.yml` file.  
+Copy registration service client-cli jar which should be located at `<Registration-Service-root-folder>/client-cli/build/libs/registration-service-cli.jar` into MVD at folder location `<MVD-root-folder>/system-tests/resources/cli-tools`. If required then update copied jar file name to `registration-service-cli.jar`, full path will be `<MVD-root-folder>/system-tests/resources/cli-tools/registration-service-cli.jar`. This `registration-service-cli.jar` will be used by `cli-tools` docker container to execute the `Registration Service` commands.
+
+From the `MVD` root folder execute the following commands to set the `Registration Launcher` path environment variable and start `MVD` using the `docker-compose.yml` file.
 
 > Note that the value of the path is relative to the build system and is only here for example. You **will need to change this**
 
@@ -149,45 +151,16 @@ docker-compose -f system-tests/docker-compose.yml up --build
 ```
 
 Once completed, following services will start within their docker containers:
+
 - 3 `EDC Connectors`
   - _consumer-us_
   - _consumer-eu_
   - _provider_ (which will also be seeded with initial required data using a [postman collection](../deployment/data/MVD.postman_collection.json))
 - A `Registration Service`
 - A `HTTP Nginx Server` (to serve DID Documents)
-- An `Azurite` blob storage service 
-  
+- An `Azurite` blob storage service
 
-_Note, the `Newman` docker container will automatically stop after seeding initial data from postman scripts._
-
-`EDC Connectors` need to be registered using `Registration Service` CLI client jar. After publishing `Registration Service` locally the client jar should be available under the `Registration Service` root project folder in _client-cli/build/libs_.
-
-> Note that the value of the path is relative to the build system and is only here for example.
-
-```bash
-# Replace path according to your local set up
-export REGISTRATION_SERVICE_CLI_JAR_PATH=c:/RegistrationService/client-cli/build/libs/registration-service-cli.jar
-
-# Register Participants
-./system-tests/resources/register-participants.sh
-```
-
-_Note for Windows PowerShell, the following commands should be run the the `MVD` root project folder._
-
-```powershell
-# Replace path according to your local set up
-
-$Env:REGISTRATION_SERVICE_CLI_JAR_PATH = "c:\RegistrationService\client-cli\build\libs\registration-service-cli.jar"
-
-# Register Provider
-java -jar $Env:REGISTRATION_SERVICE_CLI_JAR_PATH -s="http://localhost:8184/api" participants add --request="{ \`"name\`": \`"provider\`", \`"supportedProtocols\`": [ \`"ids-multipart\`" ], \`"url\`": \`"http://provider:8282\`" }"
-
-# Register Consumer-EU
-java -jar $Env:REGISTRATION_SERVICE_CLI_JAR_PATH -s="http://localhost:8184/api" participants add --request="{ \`"name\`": \`"consumer-eu\`", \`"supportedProtocols\`": [ \`"ids-multipart\`" ], \`"url\`": \`"http://consumer-eu:8282\`" }"
-
-# Register Consumer-US
-java -jar $Env:REGISTRATION_SERVICE_CLI_JAR_PATH -s="http://localhost:8184/api" participants add --request="{ \`"name\`": \`"consumer-us\`", \`"supportedProtocols\`": [ \`"ids-multipart\`" ], \`"url\`": \`"http://consumer-us:8282\`" }"
-```
+_Note, the `Newman` docker container will automatically stop after seeding initial data from postman scripts and `cli-tools` container will also automatically stop after registering participants._
 
 Set the environment variable `TEST_ENVIRONMENT` to `local` to enable local blob transfer test and then run `MVD` system test using the following command:
 
@@ -233,7 +206,7 @@ Generated keys are imported to keystores e.g. `system-tests/resources/vault/prov
 `MVD` local instances use a file-system based vault and its keys are managed using a java properties file e.g.`system-tests/resources/vault/provider/provider-vault.properties`.
 
 > ! IMPORTANT !
-> 
+>
 > *File System Vault is __NOT__ a secure vault and thus should only be used for testing purposes*
 
 <br>
@@ -247,6 +220,7 @@ Web DIDs are available under `system-tests/resources/webdid` folder. The `public
 ```bash
 docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < system-tests/resources/vault/provider/public-key.pem > key.public.jwk
 ```
+
 <br>
 
 ---

--- a/system-tests/docker-compose.yml
+++ b/system-tests/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       EDC_IAM_DID_WEB_USE_HTTPS: "false"
       EDC_CATALOG_CACHE_EXECUTION_DELAY_SECONDS: 5
       EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS: 5
-      REGISTRATION_SERVICE_API_URL: http://registration-service:8181/api
+      REGISTRATION_SERVICE_API_URL: http://registration-service:8184/authority
     depends_on:
       - did-server
       - azurite
@@ -50,7 +50,7 @@ services:
       EDC_IAM_DID_WEB_USE_HTTPS: "false"
       EDC_CATALOG_CACHE_EXECUTION_DELAY_SECONDS: 5
       EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS: 5
-      REGISTRATION_SERVICE_API_URL: http://registration-service:8181/api
+      REGISTRATION_SERVICE_API_URL: http://registration-service:8184/authority
     depends_on:
       - did-server
       - azurite
@@ -81,7 +81,7 @@ services:
       EDC_IAM_DID_WEB_USE_HTTPS: "false"
       EDC_CATALOG_CACHE_EXECUTION_DELAY_SECONDS: 5
       EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS: 5
-      REGISTRATION_SERVICE_API_URL: http://registration-service:8181/api
+      REGISTRATION_SERVICE_API_URL: http://registration-service:8184/authority
     depends_on:
       - did-server
       - azurite
@@ -141,7 +141,27 @@ services:
       args:
         JVM_ARGS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5008"
     environment:
-      EDC_API_AUTH_KEY: ApiKeyDefaultValue
+      JWT_AUDIENCE: http://registration-service:8184/authority
+      WEB_HTTP_AUTHORITY_PORT: 8184
+      WEB_HTTP_AUTHORITY_PATH: /authority
+      EDC_IAM_DID_WEB_USE_HTTPS: "false"
     ports:
-      - "8184:8181"
+      - "8184:8184"
       - "5008:5008"
+
+  # cli-tools to help setup MVD environment e.g. registering participant to authority.
+  cli-tools:
+    container_name: cli-tools
+    build:
+      context: ./resources/cli-tools
+    volumes:
+      - ./resources:/resources
+    depends_on:
+      consumer-eu:
+        condition: service_healthy
+      consumer-us:
+        condition: service_healthy
+      provider:
+        condition: service_healthy
+      registration-service:
+        condition: service_healthy

--- a/system-tests/resources/cli-tools/Dockerfile
+++ b/system-tests/resources/cli-tools/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:17-slim-buster
+
+WORKDIR /app
+
+# Copy Registration Service client jar
+COPY ./registration-service-cli.jar .
+COPY ./entrypoint.sh .
+
+ENTRYPOINT "/app/entrypoint.sh"

--- a/system-tests/resources/cli-tools/entrypoint.sh
+++ b/system-tests/resources/cli-tools/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+PARTICIPANTS=(provider consumer-eu consumer-us)
+
+# Register dataspace participants
+for i in "${PARTICIPANTS[@]}"; do
+    echo "Registering $i"
+    java -jar registration-service-cli.jar -d="did:web:did-server:$i" -k=/resources/vault/$i/private-key.pem -s='http://registration-service:8184/authority' participants add --ids-url "http://$i:8282"
+done

--- a/system-tests/resources/register-participants.sh
+++ b/system-tests/resources/register-participants.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-PARTICIPANTS=(provider consumer-eu consumer-us)
-
-# Register dataspace participants
-for i in "${PARTICIPANTS[@]}"; do
-    echo "Registering $i"
-    java -jar $REGISTRATION_SERVICE_CLI_JAR_PATH -s='http://localhost:8184/api' participants add --request='{ "name": "'$i'", "supportedProtocols": [ "ids-multipart" ], "url": "http://'$i':8282" }'
-done

--- a/system-tests/resources/webdid/consumer-eu/did.json
+++ b/system-tests/resources/webdid/consumer-eu/did.json
@@ -1,9 +1,9 @@
 {
-	"id": "did:web:consumer-eu-did-server:consumer-eu",
+	"id": "did:web:did-server:consumer-eu",
 	"@context": [
 		"https://www.w3.org/ns/did/v1",
 		{
-			"@base": "did:web:consumer-eu-did-server:consumer-eu"
+			"@base": "did:web:did-server:consumer-eu"
 		}
 	],
 	"service": [{

--- a/system-tests/resources/webdid/consumer-us/did.json
+++ b/system-tests/resources/webdid/consumer-us/did.json
@@ -1,9 +1,9 @@
 {
-	"id": "did:web:consumer-us-did-server:consumer-us",
+	"id": "did:web:did-server:consumer-us",
 	"@context": [
 		"https://www.w3.org/ns/did/v1",
 		{
-			"@base": "did:web:consumer-us-did-server:consumer-us"
+			"@base": "did:web:did-server:consumer-us"
 		}
 	],
 	"service": [{

--- a/system-tests/resources/webdid/provider/did.json
+++ b/system-tests/resources/webdid/provider/did.json
@@ -1,9 +1,9 @@
 {
-	"id": "did:web:provider-did-server:provider",
+	"id": "did:web:did-server:provider",
 	"@context": [
 		"https://www.w3.org/ns/did/v1",
 		{
-			"@base": "did:web:provider-did-server:provider"
+			"@base": "did:web:did-server:provider"
 		}
 	],
 	"service": [{


### PR DESCRIPTION
## What this PR changes/adds

Access to the Registration Service API is authenticated with JWS. Adapted accordingly:
- the Registration Service CLI call in the deployment pipeline
- the federated Directory implementation in EDC, for retrieving the participants list

## Why it does that

Authentication ensures that only actors who can assert their control of a did:web identifier can register that identifier as a dataspace participant. 

## Further notes

- Updated Registration service commit dependency for the required JWS support
- Updated Registration service URLs given new port and URL mapping (https://github.com/agera-edc/RegistrationService/pull/14)
- Updated EDC version because of a required fix (`#1575`)
- The curl command to check registration service is up doesn't work anymore, since a JWS is required. I've remove the `curl` command and let the workflow fail when deploying participants. Other options could be pursued in follow-up issues, e.g.:
  - adapt the `curl` command to succeed if a `401` is returned and fail otherwise
  - use the CLI client `list participants` command with the authority key
  - use `az container show` to check `state=running` (based on internal health check), waiting if necessary
  - use `az container exec` to run `curl` within the container, waiting if necessary
  - expose port 8181
  - use Terratest
- Also changed workflow trigger to run on all PRs, not only to main branch, to facilitate downstream fork process.

## Linked Issue(s)

https://github.com/agera-edc/MinimumViableDataspace/issues/14

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/styleguide.md) for details_)
