### PR TITLE
Add EnrollmentUrl to Did document

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -285,7 +285,7 @@ jobs:
           dashboard_image = "mvd/data-dashboard:${{ env.RESOURCES_PREFIX }}"
           application_sp_object_id = "${{ secrets.APP_OBJECT_ID }}"
           application_sp_client_id = "${{ secrets.APP_CLIENT_ID }}"
-          registration_service_api_url = "${{ needs.Deploy-Dataspace.outputs.registration_service_url }}/authority"
+          registration_service_api_url = "${{ needs.Deploy-Dataspace.outputs.registration_service_url }}"
           EOF
 
       - name: 'Az CLI login'
@@ -396,7 +396,7 @@ jobs:
             participants add \
             --ids-url "http://${{ env.EDC_HOST }}:8282"
         env:
-          REGISTRATION_SERVICE_API_URL: ${{ needs.Deploy-Dataspace.outputs.registration_service_url }}/authority
+          REGISTRATION_SERVICE_API_URL: ${{ needs.Deploy-Dataspace.outputs.registration_service_url }}
 
   Verify:
     needs:

--- a/deployment/terraform/dataspace/main.tf
+++ b/deployment/terraform/dataspace/main.tf
@@ -41,10 +41,10 @@ locals {
   edc_default_port                 = 8181
   registration_service_port        = 8182
   registration_service_path_prefix = "/authority"
-  registration_service_url         = "http://${local.registration_service_dns_label}.${var.location}.azurecontainer.io:${local.registration_service_port}"
+  registration_service_url         = "http://${local.registration_service_dns_label}.${var.location}.azurecontainer.io:${local.registration_service_port}${local.registration_service_path_prefix}"
 
-  dataspace_did_url = "did:web:${azurerm_storage_account.dataspace_did.primary_web_host}"
-  gaiax_did_url     = "did:web:${azurerm_storage_account.gaiax_did.primary_web_host}"
+  dataspace_did_uri = "did:web:${azurerm_storage_account.dataspace_did.primary_web_host}"
+  gaiax_did_uri     = "did:web:${azurerm_storage_account.gaiax_did.primary_web_host}"
 }
 
 resource "azurerm_resource_group" "dataspace" {
@@ -86,7 +86,7 @@ resource "azurerm_container_group" "registration-service" {
 
     environment_variables = {
       EDC_CONNECTOR_NAME      = local.connector_name
-      JWT_AUDIENCE            = "${local.registration_service_url}${local.registration_service_path_prefix}"
+      JWT_AUDIENCE            = local.registration_service_url
       WEB_HTTP_AUTHORITY_PORT = local.registration_service_port
       WEB_HTTP_AUTHORITY_PATH = local.registration_service_path_prefix
     }
@@ -149,11 +149,18 @@ resource "azurerm_storage_blob" "dataspace_did" {
   storage_container_name = "$web" # container used to serve static files (see static_website property on storage account)
   type                   = "Block"
   source_content = jsonencode({
-    id = local.dataspace_did_url
+    id = local.dataspace_did_uri
     "@context" = [
       "https://www.w3.org/ns/did/v1",
       {
-        "@base" = local.dataspace_did_url
+        "@base" = local.dataspace_did_uri
+      }
+    ],
+    "service" : [
+      {
+        "id" : "#registration-url",
+        "type" : "RegistrationUrl",
+        "serviceEndpoint" : local.registration_service_url
       }
     ],
     "verificationMethod" = [
@@ -189,11 +196,11 @@ resource "azurerm_storage_blob" "gaiax_did" {
   storage_container_name = "$web" # container used to serve static files (see static_website property on storage account)
   type                   = "Block"
   source_content = jsonencode({
-    id = local.gaiax_did_url
+    id = local.gaiax_did_uri
     "@context" = [
       "https://www.w3.org/ns/did/v1",
       {
-        "@base" = local.gaiax_did_url
+        "@base" = local.gaiax_did_uri
       }
     ],
     "verificationMethod" = [


### PR DESCRIPTION
## What this PR changes/adds

Include Registration service enrollment api endpoint in Dataspace Authority DID document.

## Why it does that

The Enrollment API url should be resolved from the Dataspace DID. A subsequent PR will implement that.

## Further notes

Example DID: https://mvd144dataspacedid.z16.web.core.windows.net/.well-known/did.json

```
{
  "@context": [
    "https://www.w3.org/ns/did/v1",
    {
      "@base": "did:web:mvd144dataspacedid.z16.web.core.windows.net"
    }
  ],
  "authentication": [
    "#identity-key-authority"
  ],
  "id": "did:web:mvd144dataspacedid.z16.web.core.windows.net",
  "service": [
    {
      "id": "#registration-url",
      "serviceEndpoint": "http://mvd144-registration-mvd.northeurope.azurecontainer.io:8182/authority",
      "type": "RegistrationUrl"
    }
  ],
  "verificationMethod": [
    {
      "controller": "",
      "id": "#identity-key-authority",
      "publicKeyJwk": {
        "crv": "P-256",
        "kid": "-H3sjnC_YonHsHUZ2__g3jDLuPRbdpKCXgiy2-4Eo4g",
        "kty": "EC",
        "x": "R8OVoCQIIby9GF3XUj1rTputvTLUXtnLmb0doP-PPDA",
        "y": "4E0zG6Zdma5QAnM8Zmy6jASU_f-ezlcYHB2-_qI9exI"
      },
      "type": "JsonWebKey2020"
    }
  ]
}
```

Also:
- Corrected some variable names "DID URL" into "DID URI"
- Simplified Terraform outputs by having the "/authority" registration service URL prefix contained in the output registration service URL

## Linked Issue(s)

Linked to https://github.com/agera-edc/MinimumViableDataspace/issues/43

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly?
