### PR TITLE
feat add participant-id as suffix to assets

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -381,6 +381,8 @@ jobs:
         run: curl --retry 10 --retry-all-errors --fail http://${EDC_HOST}:8181/api/check/health
 
       - name: 'Seed data'
+        env:
+          PARTICIPANT_ID: ${{ matrix.participant }}
         run: |
           npm install -g newman
           deployment/seed-data.sh

--- a/deployment/data/MVD.postman_collection.json
+++ b/deployment/data/MVD.postman_collection.json
@@ -29,7 +29,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"asset\": {\n        \"properties\": {\n            \"asset:prop:name\": \"test-document\",\n            \"asset:prop:contenttype\": \"text/plain\",\n            \"asset:prop:version\": \"1.0\",\n            \"asset:prop:id\": \"test-document\",\n            \"type\": \"AzureStorage\"\n        }\n    },\n    \"dataAddress\": {\n        \"properties\": {\n            \"type\": \"AzureStorage\",\n            \"account\": \"{{storage_account}}\",\n            \"container\": \"src-container\",\n            \"blobname\": \"text-document.txt\",\n            \"keyName\": \"{{storage_account}}-key1\"\n        }\n    }\n}",
+							"raw": "{\n    \"asset\": {\n        \"properties\": {\n            \"asset:prop:name\": \"test-document_{{participant_id}}\",\n            \"asset:prop:contenttype\": \"text/plain\",\n            \"asset:prop:version\": \"1.0\",\n            \"asset:prop:id\": \"test-document_{{participant_id}}\",\n            \"type\": \"AzureStorage\"\n        }\n    },\n    \"dataAddress\": {\n        \"properties\": {\n            \"type\": \"AzureStorage\",\n            \"account\": \"{{storage_account}}\",\n            \"container\": \"src-container\",\n            \"blobname\": \"text-document.txt\",\n            \"keyName\": \"{{storage_account}}-key1\"\n        }\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -69,7 +69,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"asset\": {\n        \"properties\": {\n            \"asset:prop:name\": \"test-document-2\",\n            \"asset:prop:contenttype\": \"text/plain\",\n            \"asset:prop:version\": \"1.0\",\n            \"asset:prop:id\": \"test-document-2\",\n            \"type\": \"AzureStorage\"\n        }\n    },\n    \"dataAddress\": {\n        \"properties\": {\n            \"type\": \"AzureStorage\",\n            \"account\": \"{{storage_account}}\",\n            \"container\": \"src-container\",\n            \"blobname\": \"text-document-2.txt\",\n            \"keyName\": \"{{storage_account}}-key1\"\n        }\n    }\n}",
+							"raw": "{\n    \"asset\": {\n        \"properties\": {\n            \"asset:prop:name\": \"test-document-2_{{participant_id}}\",\n            \"asset:prop:contenttype\": \"text/plain\",\n            \"asset:prop:version\": \"1.0\",\n            \"asset:prop:id\": \"test-document-2_{{participant_id}}\",\n            \"type\": \"AzureStorage\"\n        }\n    },\n    \"dataAddress\": {\n        \"properties\": {\n            \"type\": \"AzureStorage\",\n            \"account\": \"{{storage_account}}\",\n            \"container\": \"src-container\",\n            \"blobname\": \"text-document-2.txt\",\n            \"keyName\": \"{{storage_account}}-key1\"\n        }\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -109,7 +109,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"uid\": \"956e172f-2de1-4501-8881-057a57fd0e69\",\n  \"policy\": {\n    \"permissions\": [\n      {\n        \"edctype\": \"dataspaceconnector:permission\",\n        \"uid\": null,\n        \"target\": \"test-document\",\n        \"action\": {\n          \"type\": \"USE\",\n          \"includedIn\": null,\n          \"constraint\": null\n        },\n        \"assignee\": null,\n        \"assigner\": null,\n        \"constraints\": [],\n        \"duties\": []\n      }\n    ],\n    \"prohibitions\": [],\n    \"obligations\": [],\n    \"extensibleProperties\": {},\n    \"inheritsFrom\": null,\n    \"assigner\": null,\n    \"assignee\": null,\n    \"target\": null,\n    \"@type\": {\n      \"@policytype\": \"set\"\n    }\n  }\n}",
+							"raw": "{\n  \"uid\": \"956e172f-2de1-4501-8881-057a57fd0e69\",\n  \"policy\": {\n    \"permissions\": [\n      {\n        \"edctype\": \"dataspaceconnector:permission\",\n        \"uid\": null,\n        \"target\": \"test-document_{{participant_id}}\",\n        \"action\": {\n          \"type\": \"USE\",\n          \"includedIn\": null,\n          \"constraint\": null\n        },\n        \"assignee\": null,\n        \"assigner\": null,\n        \"constraints\": [],\n        \"duties\": []\n      }\n    ],\n    \"prohibitions\": [],\n    \"obligations\": [],\n    \"extensibleProperties\": {},\n    \"inheritsFrom\": null,\n    \"assigner\": null,\n    \"assignee\": null,\n    \"target\": null,\n    \"@type\": {\n      \"@policytype\": \"set\"\n    }\n  }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -189,7 +189,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"id\": \"4a75736e-001d-4364-8bd4-9888490edb56\",\n    \"accessPolicyId\": \"956e172f-2de1-4501-8881-057a57fd0e69\",\n    \"contractPolicyId\": \"956e172f-2de1-4501-8881-057a57fd0e69\",\n        \"criteria\": [\n            {\n                \"operandLeft\": \"asset:prop:id\",\n                \"operator\": \"=\",\n                \"operandRight\": \"test-document\"\n            }\n        ]\n}",
+							"raw": "{\n    \"id\": \"4a75736e-001d-4364-8bd4-9888490edb56\",\n    \"accessPolicyId\": \"956e172f-2de1-4501-8881-057a57fd0e69\",\n    \"contractPolicyId\": \"956e172f-2de1-4501-8881-057a57fd0e69\",\n        \"criteria\": [\n            {\n                \"operandLeft\": \"asset:prop:id\",\n                \"operator\": \"=\",\n                \"operandRight\": \"test-document_{{participant_id}}\"\n            }\n        ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -229,7 +229,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"id\": \"8dfd8f18-09ad-41f9-a2d8-368889d3e36e\",\n    \"accessPolicyId\": \"6a99c1bb-74ad-41a7-b73a-93233ffdbfb8\",\n    \"contractPolicyId\": \"6a99c1bb-74ad-41a7-b73a-93233ffdbfb8\",\n        \"criteria\": [\n            {\n                \"operandLeft\": \"asset:prop:id\",\n                \"operator\": \"=\",\n                \"operandRight\": \"test-document-2\"\n            }\n        ]\n}",
+							"raw": "{\n    \"id\": \"8dfd8f18-09ad-41f9-a2d8-368889d3e36e\",\n    \"accessPolicyId\": \"6a99c1bb-74ad-41a7-b73a-93233ffdbfb8\",\n    \"contractPolicyId\": \"6a99c1bb-74ad-41a7-b73a-93233ffdbfb8\",\n        \"criteria\": [\n            {\n                \"operandLeft\": \"asset:prop:id\",\n                \"operator\": \"=\",\n                \"operandRight\": \"test-document-2_{{participant_id}}\"\n            }\n        ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/deployment/seed-data.sh
+++ b/deployment/seed-data.sh
@@ -6,5 +6,6 @@ newman run \
   --folder "Publish Master Data" \
   --env-var data_management_url="http://$EDC_HOST:9191/api/v1/data" \
   --env-var storage_account="$ASSETS_STORAGE_ACCOUNT" \
+  --env-var participant_id="$PARTICIPANT_ID"
   --env-var api_key="$API_KEY" \
   deployment/data/MVD.postman_collection.json

--- a/deployment/seed-data.sh
+++ b/deployment/seed-data.sh
@@ -6,6 +6,6 @@ newman run \
   --folder "Publish Master Data" \
   --env-var data_management_url="http://$EDC_HOST:9191/api/v1/data" \
   --env-var storage_account="$ASSETS_STORAGE_ACCOUNT" \
-  --env-var participant_id="$PARTICIPANT_ID"
+  --env-var participant_id="$PARTICIPANT_ID" \
   --env-var api_key="$API_KEY" \
   deployment/data/MVD.postman_collection.json

--- a/system-tests/docker-compose.yml
+++ b/system-tests/docker-compose.yml
@@ -106,6 +106,7 @@ services:
       API_KEY: ApiKeyDefaultValue
       EDC_HOST: provider
       ASSETS_STORAGE_ACCOUNT: providerassets
+      PARTICIPANT_ID: provider
     depends_on:
       consumer-eu:
         condition: service_healthy

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/utils/TransferSimulationUtils.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/utils/TransferSimulationUtils.java
@@ -50,8 +50,8 @@ public abstract class TransferSimulationUtils {
 
     public static final String DESCRIPTION = "[Contract negotiation and file transfer]";
 
-    public static final String PROVIDER_ASSET_ID = "test-document";
-    public static final String EU_RESTRICTED_PROVIDER_ASSET_ID = "test-document-2";
+    public static final String PROVIDER_ASSET_ID = "test-document_provider";
+    public static final String EU_RESTRICTED_PROVIDER_ASSET_ID = "test-document-2_provider";
     public static final String PROVIDER_ASSET_FILE = "text-document.txt";
 
     public static final String TRANSFER_SUCCESSFUL = "Transfer successful";
@@ -219,7 +219,7 @@ public abstract class TransferSimulationUtils {
     private static String loadContractAgreement(String providerUrl) {
         var policy = Policy.Builder.newInstance()
                 .permission(Permission.Builder.newInstance()
-                        .target("test-document")
+                        .target("test-document_provider")
                         .action(Action.Builder.newInstance().type("USE").build())
                         .build())
                 .type(PolicyType.SET)


### PR DESCRIPTION
## What this PR changes/adds

Adds a suffix to asset IDs and names to make them unique across the dataspace.

## Why it does that

To avoid overwriting of assets in the catalog.

## Further notes

_this is as of yet untested, because neither can I log into my Azure Subscription (due to a weird login loop), nor can I run it locally due to compile errors._

## Linked Issue(s)

Closes #7 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly?
