### PR TITLE
Fix CI

### DIFF
--- a/system-tests/docker-compose.yml
+++ b/system-tests/docker-compose.yml
@@ -106,7 +106,7 @@ services:
       API_KEY: ApiKeyDefaultValue
       EDC_HOST: provider
       ASSETS_STORAGE_ACCOUNT: providerassets
-      PARTICIPANT_ID: provider
+      PARTICIPANT_ID: company1
     depends_on:
       consumer-eu:
         condition: service_healthy

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/utils/TransferSimulationUtils.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/utils/TransferSimulationUtils.java
@@ -50,8 +50,8 @@ public abstract class TransferSimulationUtils {
 
     public static final String DESCRIPTION = "[Contract negotiation and file transfer]";
 
-    public static final String PROVIDER_ASSET_ID = "test-document_provider";
-    public static final String EU_RESTRICTED_PROVIDER_ASSET_ID = "test-document-2_provider";
+    public static final String PROVIDER_ASSET_ID = "test-document_company1";
+    public static final String EU_RESTRICTED_PROVIDER_ASSET_ID = "test-document-2_company1";
     public static final String PROVIDER_ASSET_FILE = "text-document.txt";
 
     public static final String TRANSFER_SUCCESSFUL = "Transfer successful";
@@ -219,7 +219,7 @@ public abstract class TransferSimulationUtils {
     private static String loadContractAgreement(String providerUrl) {
         var policy = Policy.Builder.newInstance()
                 .permission(Permission.Builder.newInstance()
-                        .target("test-document_provider")
+                        .target(PROVIDER_ASSET_ID)
                         .action(Action.Builder.newInstance().type("USE").build())
                         .build())
                 .type(PolicyType.SET)


### PR DESCRIPTION
## What this PR changes/adds

This PR introduces minimal changes to fix the broken cloud CI pipeline on main (see failed run https://github.com/agera-edc/MinimumViableDataspace/runs/7647575335).

Test assets were renamed in https://github.com/eclipse-dataspaceconnector/MinimumViableDataspace/pull/36 but cloud tests were still using the wrong asset naming. This PR does the following fixes:
- Rename provider test asset id to match the cloud naming (test-document_company1)
- Relaxes assertions in `CatalogClientTest` to check only for catalog items matching the corresponding prefix for restricted VS non-restricted assets.

A follow-up PR will consolidate the local test setup further to match 1-1 the connector naming we have in the cloud (company 1,2,3 VS consumer-eu, consumer-us, provider) as well as the catalog entries.