### PR TITLE
JDK Logger Monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ in the detailed section referring to by linking pull requests or issues.
 
 ### Detailed Changes
 - Initial Identity Hub integration (#21)
+- Add JDK Logger
 
 #### Added
 

--- a/launcher/Dockerfile
+++ b/launcher/Dockerfile
@@ -15,6 +15,7 @@ WORKDIR /app
 RUN curl --fail -LO https://github.com/microsoft/ApplicationInsights-Java/releases/download/$APPINSIGHTS_AGENT_VERSION/applicationinsights-agent-$APPINSIGHTS_AGENT_VERSION.jar
 
 COPY ./build/libs/app.jar /app
+COPY ./src/main/resources/logging.properties /app
 
 EXPOSE 8181
 EXPOSE 9191
@@ -35,4 +36,4 @@ ENV WEB_HTTP_IDS_PATH="/api/v1/ids"
 ENV JVM_ARGS=$JVM_ARGS
 ENV APPINSIGHTS_AGENT_VERSION=$APPINSIGHTS_AGENT_VERSION
 ENTRYPOINT [ "sh", "-c", \
-    "exec java -javaagent:applicationinsights-agent-$APPINSIGHTS_AGENT_VERSION.jar $JVM_ARGS -jar app.jar"]
+    "exec java -javaagent:applicationinsights-agent-$APPINSIGHTS_AGENT_VERSION.jar -Djava.util.logging.config.file=/app/logging.properties $JVM_ARGS -jar app.jar"]

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -34,6 +34,9 @@ dependencies {
     implementation("${edcGroup}:filesystem-configuration:${edcVersion}")
     implementation("${edcGroup}:http:${edcVersion}")
 
+    // JDK Logger
+    implementation("${edcGroup}:jdk-logger-monitor:${edcVersion}")
+
     // IDS
     implementation("${edcGroup}:ids:${edcVersion}") {
         // Workaround for https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/1387

--- a/launcher/src/main/resources/logging.properties
+++ b/launcher/src/main/resources/logging.properties
@@ -1,0 +1,7 @@
+handlers = java.util.logging.ConsoleHandler
+.level = INFO
+java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format = %1$tF %1$tT %4$s : %5$s %n
+org.eclipse.dataspaceconnector.level = FINE
+org.eclipse.dataspaceconnector.handler = java.util.logging.ConsoleHandler


### PR DESCRIPTION
## What this PR changes/adds

Use JDKLogger in MVD in order to get logs pushed into Application Insights.

Connector logs:
* Cloud: see traces in Application Insights for "jdklogger2" deployment: https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/9d236f09-93d9-4f41-88a6-20201a6a1abc/resourceGroups/rg-jdklogger2/providers/Microsoft.Insights/components/jdklogger2-appinsights/searchV1
* Local: see "docker-compose logs" section in https://github.com/agera-edc/MinimumViableDataspace/runs/7666891440?check_suite_focus=true

## Why it does that

Application logs were not visible in Application Insights.

## Note

At the moment Application Insights is configured with default settings, which means that only logs with level INFO and above are captured. This can be configured as described here: https://docs.microsoft.com/en-us/azure/azure-monitor/app/java-standalone-config#auto-collected-logging

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly?
