### PR TITLE
Registration Service CLI: use Enrollment URL from DID Document

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -16,7 +16,7 @@ runs:
       with:
         repository: eclipse-dataspaceconnector/RegistrationService
         path: RegistrationService
-        ref: daa414856b42c8534e9123279112e33b366039b4
+        ref: 0b39c0b0cb1884af58d829fa8396cfa3cf609117
 
     - name: Checkout Identity Hub
       uses: actions/checkout@v2

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -132,6 +132,8 @@ jobs:
     outputs:
       app_insights_connection_string: ${{ steps.runterraform.outputs.app_insights_connection_string }}
       registration_service_url: ${{ steps.runterraform.outputs.registration_service_url }}
+      gaiax_did_host: ${{ steps.runterraform.outputs.gaiax_did_host }}
+      dataspace_did_host: ${{ steps.runterraform.outputs.dataspace_did_host }}
 
     defaults:
       run:
@@ -249,9 +251,9 @@ jobs:
       company1_api_key: ${{ steps.runterraform.outputs.company1_api_key }}
       company2_api_key: ${{ steps.runterraform.outputs.company2_api_key }}
       company3_api_key: ${{ steps.runterraform.outputs.company3_api_key }}
-      company1_did_host: ${{ steps.runterraform.outputs.company1_did_host }}
-      company2_did_host: ${{ steps.runterraform.outputs.company2_did_host }}
-      company3_did_host: ${{ steps.runterraform.outputs.company3_did_host }}
+      company1_participant_did_host: ${{ steps.runterraform.outputs.company1_participant_did_host }}
+      company2_participant_did_host: ${{ steps.runterraform.outputs.company2_participant_did_host }}
+      company3_participant_did_host: ${{ steps.runterraform.outputs.company3_participant_did_host }}
       company1_connector_name: ${{ steps.runterraform.outputs.company1_connector_name }}
       company2_connector_name: ${{ steps.runterraform.outputs.company2_connector_name }}
       company3_connector_name: ${{ steps.runterraform.outputs.company3_connector_name }}
@@ -317,7 +319,7 @@ jobs:
           terraform init -backend-config=backend.conf
           terraform apply -auto-approve
           CONNECTOR_NAME=$(terraform output -raw connector_name)
-          DID_HOST=$(terraform output -raw did_host)
+          PARTICIPANT_DID_HOST=$(terraform output -raw participant_did_host)
           EDC_HOST=$(terraform output -raw edc_host)
           ASSETS_STORAGE_ACCOUNT=$(terraform output -raw assets_storage_account)
           ASSETS_STORAGE_ACCOUNT_KEY=$(terraform output -raw assets_storage_account_key)
@@ -331,7 +333,7 @@ jobs:
           echo "ASSETS_STORAGE_ACCOUNT_KEY=$ASSETS_STORAGE_ACCOUNT_KEY" >> $GITHUB_ENV
           echo "INBOX_STORAGE_ACCOUNT=$INBOX_STORAGE_ACCOUNT" >> $GITHUB_ENV
           echo "INBOX_STORAGE_ACCOUNT_KEY=$INBOX_STORAGE_ACCOUNT_KEY" >> $GITHUB_ENV
-          echo "DID_HOST=$DID_HOST" >> $GITHUB_ENV
+          echo "PARTICIPANT_DID_HOST=$PARTICIPANT_DID_HOST" >> $GITHUB_ENV
           echo "EDC_HOST=$EDC_HOST" >> $GITHUB_ENV
           echo "API_KEY=$API_KEY" >> $GITHUB_ENV
           echo "CONNECTOR_NAME=$CONNECTOR_NAME" >> $GITHUB_ENV
@@ -340,7 +342,7 @@ jobs:
           echo "::set-output name=${{ matrix.participant }}_key_vault::${KEY_VAULT}"
           echo "::set-output name=${{ matrix.participant }}_api_key::${API_KEY}"
           echo "::set-output name=${{ matrix.participant }}_connector_name::${CONNECTOR_NAME}"
-          echo "::set-output name=${{ matrix.participant }}_did_host::${DID_HOST}"
+          echo "::set-output name=${{ matrix.participant }}_did_host::${PARTICIPANT_DID_HOST}"
           echo "::set-output name=${{ matrix.participant }}_assets_storage_account::${ASSETS_STORAGE_ACCOUNT}"
 
         env:
@@ -381,7 +383,7 @@ jobs:
           VERSION: 7.84.0
 
       - name: 'Verify did endpoint is available'
-        run: curl https://$DID_HOST/.well-known/did.json | jq '.id'
+        run: curl https://$PARTICIPANT_DID_HOST/.well-known/did.json | jq '.id'
 
       - name: 'Verify deployed EDC is healthy'
         run: curl --retry 10 --retry-all-errors --fail http://${EDC_HOST}:8181/api/check/health
@@ -407,7 +409,7 @@ jobs:
           
           java -jar identity-hub-cli-$cli_version-all.jar -s=$identityHubUrl vc add \
             -c='{"id":"'$id'","credentialSubject":{"region":"'$region'"}}' \
-            -b="did:web:$DID_HOST" \
+            -b="did:web:$PARTICIPANT_DID_HOST" \
             -i="did:web:$issuer" \
             -k="gaiaxkey.pem"
           
@@ -420,15 +422,16 @@ jobs:
 
       - name: 'Register participant'
         run: |
-          mvn dependency:copy -Dartifact=org.eclipse.dataspaceconnector.registrationservice:registration-service-cli:0.0.1-SNAPSHOT:jar:all -DoutputDirectory=.
-          java -jar registration-service-cli-0.0.1-SNAPSHOT-all.jar \
-            -s $REGISTRATION_SERVICE_API_URL \
-            -d did:web:$DID_HOST \
+          mvn dependency:copy -Dartifact=org.eclipse.dataspaceconnector.registrationservice:registration-service-cli:$REGISTRATION_SERVICE_VERSION:jar:all -DoutputDirectory=.
+          java -jar registration-service-cli-$REGISTRATION_SERVICE_VERSION-all.jar \
+            -d did:web:$DATASPACE_DID_HOST \
+            -c did:web:$PARTICIPANT_DID_HOST \
             -k participantkey.pem \
             participants add \
             --ids-url "http://${{ env.EDC_HOST }}:8282"
         env:
-          REGISTRATION_SERVICE_API_URL: ${{ needs.Deploy-Dataspace.outputs.registration_service_url }}
+          REGISTRATION_SERVICE_VERSION: 0.0.1-SNAPSHOT
+          DATASPACE_DID_HOST: ${{ needs.Deploy-Dataspace.outputs.dataspace_did_host }}
 
   Verify:
     needs:
@@ -459,9 +462,9 @@ jobs:
           CONSUMER_US_KEY_VAULT: ${{ needs.Deploy-Participants.outputs.company3_key_vault }}
           CONSUMER_EU_CATALOG_URL: http://${{ needs.Deploy-Participants.outputs.company2_edc_host }}:8181/api/federatedcatalog
           CONSUMER_US_CATALOG_URL: http://${{ needs.Deploy-Participants.outputs.company3_edc_host }}:8181/api/federatedcatalog
-          PROVIDER_DID_URL: did:web:${{ needs.Deploy-Participants.outputs.company1_did_host }}
-          CONSUMER_EU_DID_URL: did:web:${{ needs.Deploy-Participants.outputs.company2_did_host }}
-          CONSUMER_US_DID_URL: did:web:${{ needs.Deploy-Participants.outputs.company3_did_host }}
+          PROVIDER_DID_URL: did:web:${{ needs.Deploy-Participants.outputs.company1_participant_did_host }}
+          CONSUMER_EU_DID_URL: did:web:${{ needs.Deploy-Participants.outputs.company2_participant_did_host }}
+          CONSUMER_US_DID_URL: did:web:${{ needs.Deploy-Participants.outputs.company3_participant_did_host }}
           PROVIDER_IDENTITY_HUB_URL: http://${{ needs.Deploy-Participants.outputs.company1_edc_host }}:8181/api/identity-hub
           CONSUMER_EU_IDENTITY_HUB_URL: http://${{ needs.Deploy-Participants.outputs.company2_edc_host }}:8181/api/identity-hub
           CONSUMER_US_IDENTITY_HUB_URL: http://${{ needs.Deploy-Participants.outputs.company3_edc_host }}:8181/api/identity-hub

--- a/deployment/terraform/participant/outputs.tf
+++ b/deployment/terraform/participant/outputs.tf
@@ -28,7 +28,7 @@ output "connector_name" {
   value = local.connector_name
 }
 
-output "did_host" {
+output "participant_did_host" {
   value = length(azurerm_storage_blob.did) > 0 ? azurerm_storage_account.did.primary_web_host : null
 }
 

--- a/system-tests/resources/cli-tools/entrypoint.sh
+++ b/system-tests/resources/cli-tools/entrypoint.sh
@@ -11,16 +11,22 @@ for participant in "${PARTICIPANTS[@]}"; do
 
     participantName=${participantArray[0]}
     region=${participantArray[1]}
-    did="did:web:did-server:$participantName"
+    participantDid="did:web:did-server:$participantName"
 
     echo "Registering $participantName"
-    java -jar registration-service-cli.jar -d="$did" -k=/resources/vault/$participantName/private-key.pem -s='http://registration-service:8184/authority' participants add --ids-url "http://$participantName:8282"
+    java -jar registration-service-cli.jar \
+                -d="did:web:did-server:registration-service" \
+                --http-scheme \
+                -k=/resources/vault/$participantName/private-key.pem \
+                -c="$participantDid" \
+                 participants add \
+                --ids-url "http://$participantName:8282"
 
     echo "Seeding VC for $participantName"
     vcId=$(uuidgen)
     java -jar identity-hub-cli.jar -s="http://$participantName:8181/api/identity-hub" vc add \
                 -c='{"id":"'$vcId'","credentialSubject":{"region":"'$region'"}}' \
-                -b="$did" \
+                -b="$participantDid" \
                 -i="did:web:did-server:gaia-x" \
                 -k="/resources/vault/gaia-x/private-key.pem"
 done

--- a/system-tests/resources/webdid/registration-service/did.json
+++ b/system-tests/resources/webdid/registration-service/did.json
@@ -1,0 +1,31 @@
+{
+	"id": "did:web:did-server:registration-service",
+	"@context": [
+		"https://www.w3.org/ns/did/v1",
+		{
+			"@base": "did:web:did-server:registration-service"
+		}
+	],
+	"service" : [
+		{
+			"id" : "#registration-url",
+			"type" : "RegistrationUrl",
+			"serviceEndpoint" : "http://registration-service:8184/authority"
+		}
+	],
+	"verificationMethod": [{
+		"id": "#my-key-1",
+		"controller": "",
+		"type": "EcdsaSecp256k1VerificationKey2019",
+		"publicKeyJwk": {
+			"kty": "EC",
+			"kid": "r2vpmYH0Kn1urn6lrzPCzE_bVP6f4X9wb7qTT-IJODI",
+			"crv": "P-256",
+			"x": "LqW8A9NJSN7d-eLM7JqnxDpTzosTNaM8SZYOJLP7vgA",
+			"y": "ITv8jz0lGnCRx8yAFWVX6VbB57DUzGNG2m-0MxNVnis"
+		}
+	}],
+	"authentication": [
+		"#my-key-1"
+	]
+}


### PR DESCRIPTION
## What this PR changes/adds

Let Registration Service CLI use Enrollment URL from DID Document, instead of passing it from CD pipeline.

## Why it does that

The participant should only have to know the DID of the dataspace they intend to join. The enrollment URL can be resolved automatically.

## Further notes

## Linked Issue(s)

https://github.com/agera-edc/MinimumViableDataspace/issues/43

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly?
