### PR TITLE
docs: added option to setup AAD using terraform

### DIFF
--- a/docs/developer/continuous-deployment/continuous_deployment.md
+++ b/docs/developer/continuous-deployment/continuous_deployment.md
@@ -48,7 +48,16 @@ terraform init
 ### Customize `variables.tf`
 
 Please change variables in [variables.tf](../../../resources/setup_azure_ad/variables.tf) to reflect your local setup. Note that `tenant_id` and `gihub_repo` **must** be changed.
-Note also that the terraform state file (`terraform.state`) will be stored locally in the same directory. This will contain sensitive information - **do not check it in**!
+Note also that the terraform state file (`terraform.state`) will be stored locally in the same directory. This will contain sensitive information - **do not check it in or otherwise share it**!
+
+### Run `terraform`
+
+On a command line execute
+```shell
+terraform apply
+```
+This will take some time, and once it has successfully completed, your Azure Active Directory should contain all the relevant App Registrations and Service Principals
+needed for Github.
 
 ### Update Github Secrets
 

--- a/resources/setup_azure_ad/.gitignore
+++ b/resources/setup_azure_ad/.gitignore
@@ -1,0 +1,1 @@
+terraform.tfstate*

--- a/resources/setup_azure_ad/gh-actions.tf
+++ b/resources/setup_azure_ad/gh-actions.tf
@@ -19,8 +19,8 @@ resource "azuread_service_principal" "gh-actions-mvd-sp" {
 }
 
 # create password for the GH Actions SP
-resource "azuread_service_principal_password" "gh-actions-mvd-sp-password" {
-  service_principal_id = azuread_service_principal.gh-actions-mvd-sp.object_id
+resource "azuread_application_password" "gh-actions-mvd-sp-password" {
+  application_object_id = azuread_application.gh-actions-mvd.object_id
 }
 
 # Create federated credentials for the main branch, and Pull requests

--- a/resources/setup_azure_ad/gh-actions.tf
+++ b/resources/setup_azure_ad/gh-actions.tf
@@ -1,0 +1,51 @@
+# Create an application for GH Actions
+resource "azuread_application" "gh-actions-mvd" {
+  display_name     = var.gh_actions_appname
+  owners           = [data.azuread_client_config.current.object_id]
+  sign_in_audience = "AzureADMyOrg"
+
+  required_resource_access {
+    resource_app_id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
+    resource_access {
+      id   = "e1fe6dd8-ba31-4d61-89e7-88639da4683d" # User.ReadWrite
+      type = "Scope"
+    }
+  }
+}
+
+# Create a service principal
+resource "azuread_service_principal" "gh-actions-mvd-sp" {
+  application_id = azuread_application.gh-actions-mvd.application_id
+}
+
+# create password for the GH Actions SP
+resource "azuread_service_principal_password" "gh-actions-mvd-sp-password" {
+  service_principal_id = azuread_service_principal.gh-actions-mvd-sp.object_id
+}
+
+# Create federated credentials for the main branch, and Pull requests
+resource "azuread_application_federated_identity_credential" "gh-actions-fc" {
+  application_object_id = azuread_application.gh-actions-mvd.object_id
+  display_name          = var.application_fc_name
+  description           = "Github Actions federated credential for your fork"
+  audiences             = ["api://AzureADTokenExchange"]
+  issuer                = "https://token.actions.githubusercontent.com"
+  subject               = "repo:${var.github_repo}:ref:refs/heads/main"
+}
+
+resource "azuread_application_federated_identity_credential" "gh-actions-fc-pullrequest" {
+  application_object_id = azuread_application.gh-actions-mvd.object_id
+  display_name          = var.application_fc_pr_name
+  description           = "Github Actions federated credential for your fork (Pullrequests)"
+  audiences             = ["api://AzureADTokenExchange"]
+  issuer                = "https://token.actions.githubusercontent.com"
+  subject               = "repo:${var.github_repo}:pullrequest"
+}
+
+# grant GH Actions app "Owner" access to subscription
+resource "azurerm_role_assignment" "owner" {
+  scope                = data.azurerm_subscription.primary.id
+  role_definition_name = "Owner"
+  principal_id         = azuread_service_principal.gh-actions-mvd-sp.object_id
+
+}

--- a/resources/setup_azure_ad/main.tf
+++ b/resources/setup_azure_ad/main.tf
@@ -1,0 +1,34 @@
+# Configure Terraform
+terraform {
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "2.26.1"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.16.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "4.28.0"
+    }
+  }
+}
+provider "azurerm" {
+  features {
+  }
+}
+provider "azuread" {
+  tenant_id = var.tenant_id
+}
+
+provider "github" {
+
+}
+
+data "azuread_client_config" "current" {
+}
+
+data "azurerm_subscription" "primary" {
+}

--- a/resources/setup_azure_ad/mvd-runtimes.tf
+++ b/resources/setup_azure_ad/mvd-runtimes.tf
@@ -1,0 +1,28 @@
+# Create an application for MVD Runtimes
+resource "azuread_application" "mvd-runtimes" {
+  display_name     = var.mvd_runtimes_appname
+  owners           = [data.azuread_client_config.current.object_id]
+  sign_in_audience = "AzureADMyOrg"
+
+  required_resource_access {
+    resource_app_id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
+    resource_access {
+      id   = "e1fe6dd8-ba31-4d61-89e7-88639da4683d" # User.ReadWrite
+      type = "Scope"
+    }
+  }
+  feature_tags {
+    enterprise = true
+  }
+}
+
+# Create a service principal
+resource "azuread_service_principal" "mvd-runtimes-sp" {
+  application_id = azuread_application.mvd-runtimes.application_id
+
+}
+
+# create password for the GH Actions SP
+resource "azuread_service_principal_password" "mvd-runtimes-sp-password" {
+  service_principal_id = azuread_service_principal.mvd-runtimes-sp.object_id
+}

--- a/resources/setup_azure_ad/mvd-runtimes.tf
+++ b/resources/setup_azure_ad/mvd-runtimes.tf
@@ -23,6 +23,6 @@ resource "azuread_service_principal" "mvd-runtimes-sp" {
 }
 
 # create password for the GH Actions SP
-resource "azuread_service_principal_password" "mvd-runtimes-sp-password" {
-  service_principal_id = azuread_service_principal.mvd-runtimes-sp.object_id
+resource "azuread_application_password" "mvd-runtimes-sp-password" {
+  application_object_id = azuread_application.mvd-runtimes.object_id
 }

--- a/resources/setup_azure_ad/outputs.tf
+++ b/resources/setup_azure_ad/outputs.tf
@@ -4,7 +4,7 @@ output "ARM_CLIENT_ID" {
 
 output "ARM_CLIENT_SECRET" {
   sensitive = true
-  value     = azuread_service_principal_password.gh-actions-mvd-sp-password.value
+  value     = azuread_application_password.gh-actions-mvd-sp-password.value
 }
 
 output "ARM_SUBSCRIPTION_ID" {
@@ -24,7 +24,7 @@ output "APP_OBJECT_ID" {
 }
 output "APP_CLIENT_SECRET" {
   sensitive = true
-  value     = azuread_service_principal_password.mvd-runtimes-sp-password.value
+  value     = azuread_application_password.mvd-runtimes-sp-password.value
 }
 
 output "ACR_NAME" {

--- a/resources/setup_azure_ad/outputs.tf
+++ b/resources/setup_azure_ad/outputs.tf
@@ -1,0 +1,52 @@
+output "ARM_CLIENT_ID" {
+  value = azuread_application.gh-actions-mvd.application_id
+}
+
+output "ARM_CLIENT_SECRET" {
+  sensitive = true
+  value     = azuread_service_principal_password.gh-actions-mvd-sp-password.value
+}
+
+output "ARM_SUBSCRIPTION_ID" {
+  value = data.azurerm_subscription.primary.subscription_id
+}
+
+output "ARM_TENANT_ID" {
+  value = var.tenant_id
+}
+
+output "APP_CLIENT_ID" {
+  value = azuread_application.mvd-runtimes.application_id
+}
+
+output "APP_OBJECT_ID" {
+  value = azuread_service_principal.mvd-runtimes-sp.object_id
+}
+output "APP_CLIENT_SECRET" {
+  sensitive = true
+  value     = azuread_service_principal_password.mvd-runtimes-sp-password.value
+}
+
+output "ACR_NAME" {
+  value = var.acr_name
+}
+
+output "COMMON_RESOURCE_GROUP" {
+  value = var.common_resourcegroup
+}
+
+output "COMMON_RESOURCE_GROUP_LOCATION" {
+  value = var.common_resourcegroup_location
+}
+
+output "TERRAFORM_STATE_CONTAINER" {
+  value = var.tf_state_container
+}
+
+output "TERRAFORM_STATE_STORAGE_ACCOUNT" {
+  value = var.tf_state_storageaccount
+}
+
+output "GH_REPO" {
+  value = var.github_repo
+}

--- a/resources/setup_azure_ad/set-gh-secrets.sh
+++ b/resources/setup_azure_ad/set-gh-secrets.sh
@@ -1,0 +1,15 @@
+REPO=$(terraform output -raw GH_REPO)
+gh="gh --repo $REPO"
+
+$gh secret set ACR_NAME --body "$(terraform output -raw ACR_NAME)"
+$gh secret set ARM_CLIENT_ID --body "$(terraform output -raw ARM_CLIENT_ID)"
+$gh secret set ARM_CLIENT_SECRET --body "$(terraform output -raw ARM_CLIENT_SECRET)"
+$gh secret set ARM_SUBSCRIPTION_ID --body "$(terraform output -raw ARM_SUBSCRIPTION_ID)"
+$gh secret set ARM_TENANT_ID --body "$(terraform output -raw ARM_TENANT_ID)"
+$gh secret set APP_CLIENT_ID --body "$(terraform output -raw APP_CLIENT_ID)"
+$gh secret set APP_CLIENT_SECRET --body "$(terraform output -raw APP_CLIENT_SECRET)"
+$gh secret set APP_OBJECT_ID --body "$(terraform output -raw APP_OBJECT_ID)"
+$gh secret set COMMON_RESOURCE_GROUP --body "$(terraform output -raw COMMON_RESOURCE_GROUP)"
+$gh secret set COMMON_RESOURCE_GROUP_LOCATION --body "$(terraform output -raw COMMON_RESOURCE_GROUP_LOCATION)"
+$gh secret set TERRAFORM_STATE_CONTAINER --body "$(terraform output -raw TERRAFORM_STATE_CONTAINER)"
+$gh secret set TERRAFORM_STATE_STORAGE_ACCOUNT --body "$(terraform output -raw TERRAFORM_STATE_STORAGE_ACCOUNT)"

--- a/resources/setup_azure_ad/variables.tf
+++ b/resources/setup_azure_ad/variables.tf
@@ -1,0 +1,44 @@
+# supply the tenant ID for your Azure Tenant here
+variable "tenant_id" {
+  default = "<YOUR_TENANT_ID>"
+}
+# App registration name for the Federated Credential for GH Actions
+variable "gh_actions_appname" {
+  default = "GithubActions-MVD"
+}
+# App registration name for the MVD runtimes (=connectors)
+variable "mvd_runtimes_appname" {
+  default = "MVD-Runtimes"
+}
+# Name for the federated credential: GH Actions can deploy resources (on push)
+variable "application_fc_name" {
+  default = "GithubActions-MVD-FC"
+}
+# Name for the federated credential: GH Actions can deploy resources (on pull-request)
+variable "application_fc_pr_name" {
+  default = "GithubActions-MVD-FC-Pullrequest"
+}
+# name of your fork of MVD
+variable "github_repo" {
+  default = "<YOUR_FORK>/MinimumViableDataspace"
+}
+# name of the storage account that'll hold the Terraform State for MVD deployments
+variable "tf_state_storageaccount" {
+  default = "mvdtfstate"
+}
+# name of the storage container that'll hold the Terraform State for MVD deployments
+variable "tf_state_container" {
+  default = "mvdtfstate"
+}
+# RG location
+variable "common_resourcegroup_location" {
+  default = "northeurope"
+}
+# Resource group that'll contain common resources, such as the ACR
+variable "common_resourcegroup" {
+  default = "mvd-common"
+}
+# Name of the Azure Container Registry that'll hold all docker images
+variable "acr_name" {
+  default = "acrmvd"
+}


### PR DESCRIPTION
## What this PR changes/adds

Adds terraform scripts to setup AppRegs and SPs for MVD in Azure AD automatically. Updates documentation.
Tested on EDC upstream.

## Why it does that

to provide an alternative to the manual way through Azure Portal.

## Further notes

.
## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly?
