### PR TITLE
chore: bump EDC version to M5.1

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -9,7 +9,7 @@ runs:
       with:
         repository: eclipse-dataspaceconnector/DataSpaceConnector
         path: DataSpaceConnector
-        ref: v0.0.1-milestone-5
+        ref: v0.0.1-milestone-5.1
 
     - name: Checkout Registration Service
       uses: actions/checkout@v2


### PR DESCRIPTION
## What this PR changes/adds

Updates CI and local build files to use EDC Version `0.0.1-milestone-5.1` which includes a critical fix regarding the catalog. 

## Why it does that

The catalog clearing process was fixed after M5 was released, so that fix never found its way into MVD.


## Further notes

Checking out and building locally the EDC Code base was replaced by depending against artifacts from MavenCentral.

RegistrationService and IdentityHub are still being checked out and built locally.

## Linked Issue(s)

Closes https://github.com/agera-edc/minimumViableDataspace/issues/193

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly?
