### PR TITLE
Add codeql and checkstyle

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -15,22 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/gradle-setup
+
+      - name: Run Checkstyle
+        run: ./gradlew checkstyleMain checkstyleTest
 
       - name: Check Terraform files are properly formatted (run "terraform fmt -recursive" to fix)
         run: |
           terraform fmt -recursive
           git diff --exit-code
-
-      # run Checkstyle explicitly (as opposed to within gradle) due to better reporting capabilities
-      - name: Run Checkstyle
-        if: github.event_name == 'pull_request'
-        uses: nikitasavinov/checkstyle-action@0.6.0
-        with:
-          checkstyle_config: resources/checkstyle-config.xml
-          level: error
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tool_name: 'checkstyle'
-          checkstyle_version: '9.0'
-          reporter: 'github-pr-check'
-          # Include only violations on added or modified files
-          filter_mode: 'file'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,49 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java' ]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/gradle-setup
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-and-quality
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+      # Compiles production Java source (without tests)
+      - name: Build
+        run: ./gradlew compileJava --no-daemon
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,10 +2,19 @@ plugins {
     java
     `java-library`
     jacoco
+    checkstyle
 }
 
 allprojects {
     apply(plugin = "java")
+    apply(plugin = "checkstyle")
+
+    checkstyle {
+        toolVersion = "9.0"
+        configFile = rootProject.file("resources/checkstyle-config.xml")
+        configDirectory.set(rootProject.file("resources"))
+        maxErrors = 0 // does not tolerate errors
+    }
 
     repositories {
         mavenCentral()

--- a/docs/developer/decision-records/2022-08-15-code-quality-tooling/README.md
+++ b/docs/developer/decision-records/2022-08-15-code-quality-tooling/README.md
@@ -1,0 +1,13 @@
+# Code Quality
+
+## Decision
+
+Use [Checkstyle](https://checkstyle.sourceforge.io/) and [CodeQL](https://codeql.github.com/) static code analysis tools to guarantee adherence to coding standards and discover potential vulnerabilities.
+
+## Rationale
+
+Both Checkstyle and CodeQL are already in use in the EDC framework, so these tools are the natural choice in related projects like the MVD as well.
+
+## Approach
+
+Checkstyle checks and CodeQL analysis need to run on Pull Requests in both upstream and forked repositories.


### PR DESCRIPTION
## What this PR changes/adds

- Run checkstyle on PRs in both upstream and forks.
- Run CodeQL on  PRs in both upstream and forks.

workflow failure due to checkstyle as an example: https://github.com/eclipse-dataspaceconnector/MinimumViableDataspace/runs/7837971765?check_suite_focus=true

## Why it does that

Both Checkstyle and CodeQL are already in use in the EDC framework, so these tools are the natural choice in related projects like the Identity Hub as well.

## Linked Issue(s)

Relates to https://github.com/agera-edc/MinimumViableDataspace/issues/252

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly?
