### PR TITLE
Fix: check participant status to make sure the participant is onboarded

### DIFF
--- a/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/RegistrationServiceNodeDirectory.java
+++ b/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/RegistrationServiceNodeDirectory.java
@@ -45,6 +45,7 @@ public class RegistrationServiceNodeDirectory implements FederatedCacheNodeDirec
     @Override
     public List<FederatedCacheNode> getAll() {
         return apiClient.listParticipants().stream()
+                .filter(participant -> participant.getStatus() == ParticipantDto.StatusEnum.ONBOARDED)
                 .map(resolver::toFederatedCacheNode)
                 .filter(AbstractResult::succeeded)
                 .map(AbstractResult::getContent)


### PR DESCRIPTION
Currently, the crawler will fetch catalog data from participants that have a DENIED status.

## What this PR changes/adds

Check participant status

## Why it does that

You only want to crawl participants that are ONBOARDED