### PR TITLE
feat: Add link to self-description in DID document

### DIFF
--- a/deployment/terraform/dataspace/dataspace-did.tf
+++ b/deployment/terraform/dataspace/dataspace-did.tf
@@ -1,0 +1,52 @@
+# Internal Dataspace Authority resources (Dataspace DID)
+resource "azurerm_storage_account" "dataspace_did" {
+  name                     = "${var.prefix}dataspacedid"
+  resource_group_name      = azurerm_resource_group.dataspace.name
+  location                 = var.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  account_kind             = "StorageV2"
+  static_website {}
+}
+
+resource "azurerm_storage_blob" "dataspace_did" {
+  name                 = ".well-known/did.json" # `.well-known` path is defined by did:web specification
+  storage_account_name = azurerm_storage_account.dataspace_did.name
+  # Create did blob only if public_key_jwk_file is provided. Default public_key_jwk_file value is null.
+  count                  = var.public_key_jwk_file_authority == null ? 0 : 1
+  storage_container_name = "$web" # container used to serve static files (see static_website property on storage account)
+  type                   = "Block"
+  source_content = jsonencode({
+    id = local.dataspace_did_uri
+    "@context" = [
+      "https://www.w3.org/ns/did/v1",
+      {
+        "@base" = local.dataspace_did_uri
+      }
+    ],
+    "service" : [
+      {
+        "id" : "#registration-url",
+        "type" : "RegistrationUrl",
+        "serviceEndpoint" : local.registration_service_url
+      },
+      {
+        "id" : "#self-description-url",
+        "type" : "SelfDescription",
+        "serviceEndpoint" : "http://${local.registration_service_host}:${local.edc_default_port}/api/identity-hub/self-description"
+      }
+    ],
+    "verificationMethod" = [
+      {
+        "id"           = "#identity-key-authority"
+        "controller"   = ""
+        "type"         = "JsonWebKey2020"
+        "publicKeyJwk" = jsondecode(file(var.public_key_jwk_file_authority))
+      }
+    ],
+    "authentication" : [
+      "#identity-key-authority"
+  ] })
+  content_type = "application/json"
+}
+

--- a/deployment/terraform/dataspace/gaiax-did.tf
+++ b/deployment/terraform/dataspace/gaiax-did.tf
@@ -1,0 +1,41 @@
+# GAIA-X Authority resources
+resource "azurerm_storage_account" "gaiax_did" {
+  name                     = "${var.prefix}gaiaxdid"
+  resource_group_name      = azurerm_resource_group.dataspace.name
+  location                 = var.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  account_kind             = "StorageV2"
+  static_website {}
+}
+
+resource "azurerm_storage_blob" "gaiax_did" {
+  name                 = ".well-known/did.json" # `.well-known` path is defined by did:web specification
+  storage_account_name = azurerm_storage_account.gaiax_did.name
+  # Create did blob only if public_key_jwk_file is provided. Default public_key_jwk_file value is null.
+  count                  = var.public_key_jwk_file_gaiax == null ? 0 : 1
+  storage_container_name = "$web" # container used to serve static files (see static_website property on storage account)
+  type                   = "Block"
+  source_content = jsonencode({
+    id = local.gaiax_did_uri
+    "@context" = [
+      "https://www.w3.org/ns/did/v1",
+      {
+        "@base" = local.gaiax_did_uri
+      }
+    ],
+    "service" : [],
+    "verificationMethod" = [
+      {
+        "id"           = "#identity-key-gaiax"
+        "controller"   = ""
+        "type"         = "JsonWebKey2020"
+        "publicKeyJwk" = jsondecode(file(var.public_key_jwk_file_gaiax))
+      }
+    ],
+    "authentication" : [
+      "#identity-key-gaiax"
+  ] })
+  content_type = "application/json"
+}
+

--- a/deployment/terraform/dataspace/main.tf
+++ b/deployment/terraform/dataspace/main.tf
@@ -164,64 +164,6 @@ resource "azurerm_role_assignment" "current-user-secretsofficer" {
   principal_id         = data.azurerm_client_config.current_client.object_id
 }
 
-# Internal Dataspace Authority resources (Dataspace DID)
-resource "azurerm_storage_account" "dataspace_did" {
-  name                     = "${var.prefix}dataspacedid"
-  resource_group_name      = azurerm_resource_group.dataspace.name
-  location                 = var.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-  account_kind             = "StorageV2"
-  static_website {}
-}
-
-resource "azurerm_storage_blob" "dataspace_did" {
-  name                 = ".well-known/did.json" # `.well-known` path is defined by did:web specification
-  storage_account_name = azurerm_storage_account.dataspace_did.name
-  # Create did blob only if public_key_jwk_file is provided. Default public_key_jwk_file value is null.
-  count                  = var.public_key_jwk_file_authority == null ? 0 : 1
-  storage_container_name = "$web" # container used to serve static files (see static_website property on storage account)
-  type                   = "Block"
-  source_content = jsonencode({
-    id = local.dataspace_did_uri
-    "@context" = [
-      "https://www.w3.org/ns/did/v1",
-      {
-        "@base" = local.dataspace_did_uri
-      }
-    ],
-    "service" : [
-      {
-        "id" : "#registration-url",
-        "type" : "RegistrationUrl",
-        "serviceEndpoint" : local.registration_service_url
-      }
-    ],
-    "verificationMethod" = [
-      {
-        "id"           = "#identity-key-authority"
-        "controller"   = ""
-        "type"         = "JsonWebKey2020"
-        "publicKeyJwk" = jsondecode(file(var.public_key_jwk_file_authority))
-      }
-    ],
-    "authentication" : [
-      "#identity-key-authority"
-  ] })
-  content_type = "application/json"
-}
-
-# GAIA-X Authority resources
-resource "azurerm_storage_account" "gaiax_did" {
-  name                     = "${var.prefix}gaiaxdid"
-  resource_group_name      = azurerm_resource_group.dataspace.name
-  location                 = var.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-  account_kind             = "StorageV2"
-  static_website {}
-}
-
 resource "azurerm_storage_account" "shared" {
   name                     = "${var.prefix}${local.dataspace_authority_name}shared"
   resource_group_name      = azurerm_resource_group.dataspace.name
@@ -236,34 +178,3 @@ resource "azurerm_storage_share" "share" {
   storage_account_name = azurerm_storage_account.shared.name
   quota                = 1
 }
-
-resource "azurerm_storage_blob" "gaiax_did" {
-  name                 = ".well-known/did.json" # `.well-known` path is defined by did:web specification
-  storage_account_name = azurerm_storage_account.gaiax_did.name
-  # Create did blob only if public_key_jwk_file is provided. Default public_key_jwk_file value is null.
-  count                  = var.public_key_jwk_file_gaiax == null ? 0 : 1
-  storage_container_name = "$web" # container used to serve static files (see static_website property on storage account)
-  type                   = "Block"
-  source_content = jsonencode({
-    id = local.gaiax_did_uri
-    "@context" = [
-      "https://www.w3.org/ns/did/v1",
-      {
-        "@base" = local.gaiax_did_uri
-      }
-    ],
-    "service" : [],
-    "verificationMethod" = [
-      {
-        "id"           = "#identity-key-gaiax"
-        "controller"   = ""
-        "type"         = "JsonWebKey2020"
-        "publicKeyJwk" = jsondecode(file(var.public_key_jwk_file_gaiax))
-      }
-    ],
-    "authentication" : [
-      "#identity-key-gaiax"
-  ] })
-  content_type = "application/json"
-}
-

--- a/deployment/terraform/participant/did.tf
+++ b/deployment/terraform/participant/did.tf
@@ -1,0 +1,57 @@
+resource "azurerm_storage_account" "did" {
+  name                     = "${var.prefix}${var.participant_name}did"
+  resource_group_name      = azurerm_resource_group.participant.name
+  location                 = azurerm_resource_group.participant.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  account_kind             = "StorageV2"
+  static_website {}
+}
+
+resource "azurerm_storage_blob" "did" {
+  name                 = ".well-known/did.json" # `.well-known` path is defined by did:web specification
+  storage_account_name = azurerm_storage_account.did.name
+  # Create did blob only if public_key_jwk_file is provided. Default public_key_jwk_file value is null.
+  count                  = var.public_key_jwk_file == null ? 0 : 1
+  storage_container_name = "$web"
+  # container used to serve static files (see static_website property on storage account)
+  type = "Block"
+  source_content = jsonencode({
+    id = local.did_url
+    "@context" = [
+      "https://www.w3.org/ns/did/v1",
+      {
+        "@base" = local.did_url
+      }
+    ],
+    "service" : [
+      {
+        "id" : "#identity-hub-url",
+        "type" : "IdentityHub",
+        "serviceEndpoint" : "http://${azurerm_container_group.edc.fqdn}:${local.edc_default_port}/api/identity-hub"
+      },
+      {
+        "id" : "#ids-url",
+        "type" : "IDSMessaging",
+        "serviceEndpoint" : "http://${urlencode(azurerm_container_group.edc.fqdn)}:${local.edc_ids_port}"
+      },
+      {
+        "id" : "#self-description-url",
+        "type" : "SelfDescription",
+        "serviceEndpoint" : "http://${azurerm_container_group.edc.fqdn}:${local.edc_default_port}/api/identity-hub/self-description"
+      }
+    ],
+    "verificationMethod" = [
+      {
+        "id"           = "#identity-key-1"
+        "controller"   = ""
+        "type"         = "JsonWebKey2020"
+        "publicKeyJwk" = jsondecode(file(var.public_key_jwk_file))
+      }
+    ],
+    "authentication" : [
+      "#identity-key-1"
+    ]
+  })
+  content_type = "application/json"
+}

--- a/deployment/terraform/participant/main.tf
+++ b/deployment/terraform/participant/main.tf
@@ -226,16 +226,6 @@ resource "azurerm_storage_account" "assets" {
   account_kind             = "StorageV2"
 }
 
-resource "azurerm_storage_account" "did" {
-  name                     = "${var.prefix}${var.participant_name}did"
-  resource_group_name      = azurerm_resource_group.participant.name
-  location                 = azurerm_resource_group.participant.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-  account_kind             = "StorageV2"
-  static_website {}
-}
-
 resource "azurerm_storage_account" "inbox" {
   name                     = "${var.prefix}${var.participant_name}inbox"
   resource_group_name      = azurerm_resource_group.participant.name
@@ -279,47 +269,4 @@ resource "azurerm_storage_blob" "testfile2" {
   storage_container_name = azurerm_storage_container.assets_container.name
   type                   = "Block"
   source                 = "sample-data/text-document.txt"
-}
-
-resource "azurerm_storage_blob" "did" {
-  name                 = ".well-known/did.json" # `.well-known` path is defined by did:web specification
-  storage_account_name = azurerm_storage_account.did.name
-  # Create did blob only if public_key_jwk_file is provided. Default public_key_jwk_file value is null.
-  count                  = var.public_key_jwk_file == null ? 0 : 1
-  storage_container_name = "$web"
-  # container used to serve static files (see static_website property on storage account)
-  type = "Block"
-  source_content = jsonencode({
-    id = local.did_url
-    "@context" = [
-      "https://www.w3.org/ns/did/v1",
-      {
-        "@base" = local.did_url
-      }
-    ],
-    "service" : [
-      {
-        "id" : "#identity-hub-url",
-        "type" : "IdentityHub",
-        "serviceEndpoint" : "http://${azurerm_container_group.edc.fqdn}:${local.edc_default_port}/api/identity-hub"
-      },
-      {
-        "id" : "#ids-url",
-        "type" : "IDSMessaging",
-        "serviceEndpoint" : "http://${urlencode(azurerm_container_group.edc.fqdn)}:${local.edc_ids_port}"
-      }
-    ],
-    "verificationMethod" = [
-      {
-        "id"           = "#identity-key-1"
-        "controller"   = ""
-        "type"         = "JsonWebKey2020"
-        "publicKeyJwk" = jsondecode(file(var.public_key_jwk_file))
-      }
-    ],
-    "authentication" : [
-      "#identity-key-1"
-    ]
-  })
-  content_type = "application/json"
 }

--- a/system-tests/resources/webdid/company1/did.json
+++ b/system-tests/resources/webdid/company1/did.json
@@ -16,6 +16,11 @@
 			"id": "#ids-url",
 			"type": "IDSMessaging",
 			"serviceEndpoint": "http://company1:8282"
+		},
+		{
+			"id": "#self-description-url",
+			"type": "SelfDescription",
+			"serviceEndpoint": "http://company1:8181/api/identity-hub/self-description"
 		}
 	],
 	"verificationMethod": [{

--- a/system-tests/resources/webdid/company2/did.json
+++ b/system-tests/resources/webdid/company2/did.json
@@ -16,6 +16,11 @@
 			"id": "#ids-url",
 			"type": "IDSMessaging",
 			"serviceEndpoint": "http://company2:8282"
+		},
+		{
+			"id": "#self-description-url",
+			"type": "SelfDescription",
+			"serviceEndpoint": "http://company2:8181/api/identity-hub/self-description"
 		}
 	],
 	"verificationMethod": [{

--- a/system-tests/resources/webdid/company3/did.json
+++ b/system-tests/resources/webdid/company3/did.json
@@ -16,6 +16,11 @@
 			"id": "#ids-url",
 			"type": "IDSMessaging",
 			"serviceEndpoint": "http://company3:8282"
+		},
+		{
+			"id": "#self-description-url",
+			"type": "SelfDescription",
+			"serviceEndpoint": "http://company3:8181/api/identity-hub/self-description"
 		}
 	],
 	"verificationMethod": [{

--- a/system-tests/resources/webdid/registration-service/did.json
+++ b/system-tests/resources/webdid/registration-service/did.json
@@ -11,6 +11,11 @@
 			"id": "#registration-url",
 			"type": "RegistrationUrl",
 			"serviceEndpoint": "http://registration-service:8184/authority"
+		},
+		{
+			"id": "#self-description-url",
+			"type": "SelfDescription",
+			"serviceEndpoint": "http://registration-service:8181/api/identity-hub/self-description"
 		}
 	],
 	"verificationMethod": [


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a reference to the Self-Description endpoint exposed by the Identity Hub in all DID documents (participants + authority).

## Why it does that

DID document should reference all service endpoints that can be targeted externally, which includes the Self-Description endpoint.

## Linked Issue(s)

Closes https://github.com/agera-edc/MinimumViableDataspace/issues/187

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly?
