### PR TITLE
chore: Terraform OIDC

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -210,10 +210,9 @@ jobs:
           echo "::set-output name=registration_service_host::${registration_service_host}"
 
         env:
-          # Authentication settings for Terraform AzureRM provider
+          # Authentication settings for Terraform AzureRM provider using OpenID Connect
           # See https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
           # Terraform variables not included in terraform.tfvars.
@@ -364,10 +363,9 @@ jobs:
 
         env:
 
-          # Authentication settings for Terraform AzureRM provider
+          # Authentication settings for Terraform AzureRM provider using OpenID Connect
           # See https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 

--- a/.github/workflows/destroy.yaml
+++ b/.github/workflows/destroy.yaml
@@ -74,10 +74,9 @@ jobs:
           terraform init -backend-config=backend.conf
           terraform destroy -auto-approve
         env:
-          # Authentication settings for Terraform AzureRM provider
+          # Authentication settings for Terraform AzureRM provider using OpenID Connect
           # See https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
@@ -126,10 +125,9 @@ jobs:
           terraform init -backend-config=backend.conf
           terraform destroy -auto-approve
         env:
-          # Authentication settings for Terraform AzureRM provider
+          # Authentication settings for Terraform AzureRM provider using OpenID Connect
           # See https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 

--- a/deployment/terraform/dataspace/main.tf
+++ b/deployment/terraform/dataspace/main.tf
@@ -2,14 +2,17 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.1.0"
+      version = ">= 3.7.0"
     }
   }
 
-  backend "azurerm" {}
+  backend "azurerm" {
+    use_oidc = true
+  }
 }
 
 provider "azurerm" {
+  use_oidc = true
   features {
     key_vault {
       purge_soft_delete_on_destroy = true

--- a/deployment/terraform/participant/main.tf
+++ b/deployment/terraform/participant/main.tf
@@ -2,14 +2,17 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.1.0"
+      version = ">= 3.7.0"
     }
   }
 
-  backend "azurerm" {}
+  backend "azurerm" {
+    use_oidc = true
+  }
 }
 
 provider "azurerm" {
+  use_oidc = true
   features {
     key_vault {
       purge_soft_delete_on_destroy = true

--- a/docs/developer/continuous-deployment/continuous_deployment.md
+++ b/docs/developer/continuous-deployment/continuous_deployment.md
@@ -132,12 +132,6 @@ Click **Add credential** to add another credential (for the previously created a
 
 Click **Add** to create the credential.
 
-#### Create Client Secret for GitHub Actions
-
-Navigate to the **Client secrets** tab (for the previously created application (e.g. *"MVD GitHub Actions App"*), under **Certificates & secrets**), and select **New client secret**. Create a new client secret by entering a **Description** (e.g. *"mvd-client-secret"*) and clicking **Add**.
-
-Take note of the client secret (**Value**) and keep it safe (will be required to configure a GitHub secret below).
-
 #### Grant Permissions for Azure Subscription
 
 To allow GitHub Actions to deploy resources to your Azure subscription, grant the application created above Owner permissions on your Azure subscription.
@@ -157,18 +151,17 @@ Now click on **Select members**, search for the application created above (e.g. 
 
 #### Configure GitHub Secrets for GitHub Actions
 
-Finally, the application (client) ID and the application client secret needs to be made available to your GitHub repository using [GitHub secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
+Finally, the application (client) ID needs to be made available to your GitHub repository using [GitHub secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
 
 To configure GitHub Secrets, navigate to your `MinimumViableDataspace` repository, select **Settings**, navigate to **Secrets** and then **Actions**, and click **New repository secret** to create a new secret.
 
 ![GitHub Actions secrets](GitHub-Actions-secrets.png)
 
-Configure the following GitHub secrets with the values from the steps above:
+Configure the following GitHub secrets with the value from the steps above:
 
 | Secret name         | Value                          |
 | ------------------- | ------------------------------ |
 | `ARM_CLIENT_ID`     | The application (client) ID of the application created above (e.g. *"MVD GitHub Actions App"*). |
-| `ARM_CLIENT_SECRET` | The application client secret (**Value**) created above. |
 
 ### Create Service Identity for MVD Runtimes
 

--- a/resources/setup_azure_ad/gh-actions.tf
+++ b/resources/setup_azure_ad/gh-actions.tf
@@ -18,11 +18,6 @@ resource "azuread_service_principal" "gh-actions-mvd-sp" {
   application_id = azuread_application.gh-actions-mvd.application_id
 }
 
-# create password for the GH Actions SP
-resource "azuread_application_password" "gh-actions-mvd-sp-password" {
-  application_object_id = azuread_application.gh-actions-mvd.object_id
-}
-
 # Create federated credentials for the main branch, and Pull requests
 resource "azuread_application_federated_identity_credential" "gh-actions-fc" {
   application_object_id = azuread_application.gh-actions-mvd.object_id

--- a/resources/setup_azure_ad/outputs.tf
+++ b/resources/setup_azure_ad/outputs.tf
@@ -2,11 +2,6 @@ output "ARM_CLIENT_ID" {
   value = azuread_application.gh-actions-mvd.application_id
 }
 
-output "ARM_CLIENT_SECRET" {
-  sensitive = true
-  value     = azuread_application_password.gh-actions-mvd-sp-password.value
-}
-
 output "ARM_SUBSCRIPTION_ID" {
   value = data.azurerm_subscription.primary.subscription_id
 }

--- a/resources/setup_azure_ad/set-gh-secrets.sh
+++ b/resources/setup_azure_ad/set-gh-secrets.sh
@@ -3,7 +3,6 @@ gh="gh --repo $REPO"
 
 $gh secret set ACR_NAME --body "$(terraform output -raw ACR_NAME)"
 $gh secret set ARM_CLIENT_ID --body "$(terraform output -raw ARM_CLIENT_ID)"
-$gh secret set ARM_CLIENT_SECRET --body "$(terraform output -raw ARM_CLIENT_SECRET)"
 $gh secret set ARM_SUBSCRIPTION_ID --body "$(terraform output -raw ARM_SUBSCRIPTION_ID)"
 $gh secret set ARM_TENANT_ID --body "$(terraform output -raw ARM_TENANT_ID)"
 $gh secret set APP_CLIENT_ID --body "$(terraform output -raw APP_CLIENT_ID)"


### PR DESCRIPTION
## What this PR changes/adds

Authenticate Terraform to ARM using [Service Principal with Open ID Connect](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_oidc) instead of [Service Principal with a Client Secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_client_secret)

## Why it does that

This simplifies setup and increases security.

## Further notes

Support for OpenID Connect was added in version 3.7.0 of the Terraform AzureRM provider.

## Linked Issue(s)

Closes https://github.com/eclipse-dataspaceconnector/MinimumViableDataspace/issues/78

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly?
