### PR TITLE
fix: Fix context path for Registration Service in docker-compose file

### DIFF
--- a/system-tests/docker-compose.yml
+++ b/system-tests/docker-compose.yml
@@ -150,7 +150,7 @@ services:
     container_name: registration-service
     build:
       #e.g. /home/user/RegistrationService/launcher
-      context: ./launchers/registrationservice
+      context: ../launchers/registrationservice
       args:
         JVM_ARGS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5008"
     environment:


### PR DESCRIPTION
## What this PR changes/adds

Fix incorrect context path of Registration Service.

## Linked Issue(s)

Closes #85 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly?
